### PR TITLE
Probability-adjusted priority sorting

### DIFF
--- a/conf/base/catalog.yml
+++ b/conf/base/catalog.yml
@@ -29,6 +29,11 @@ p_contact_model:
   filepath: data/04_models/p_contact_model.pkl
   backend: dill
 
+p_transition_model:
+  type: pickle.PickleDataset
+  filepath: data/04_models/p_transition_model.pkl
+  backend: dill
+
 p_contact_idata:
   type: pickle.PickleDataset
   filepath: data/04_models/p_contact_idata.pkl

--- a/research-notes.md
+++ b/research-notes.md
@@ -1,0 +1,60 @@
+# Research Notes — Caller Contact Probability Integration
+
+## Problem statement & requirements
+- Need to surface the Kedro-derived probability of contact (logistic regression of contact success vs CQ SNR) for Callers in the UI.
+- Goal: rank Callers by distance **weighted by** probability of contact; Hunters are not modeled yet.
+- Integration should align data flowing from Kedro outputs into the Shiny UI tables used for prioritization.
+
+## What we found
+- **Model location:** `src/digi_dx/pipelines/p_contact/nodes.py` and `pipeline.py`. Bayesian logistic regression (`bambi`) predicting `p(success | snr_cq)` across SNR -30..30 dB; outputs summarized to `inference::table#ContactProbabilities` with `p_mean/p_lower/p_upper` per integer SNR.
+- **Inputs to model:** `prepare_attempted_contacts` joins Reply_Tx with heard CQ_Rx and Signoff_Tx, filters reply delay=15s, aggregates by `caller_callsign` with attempts, last_reply, mean `snr_cq`; joins signoff timestamps. (Note: no explicit `success` column currently set—needs clarification.)
+- **Current prioritization (UI-facing):** `active_callsigns` pipeline builds `table#Callers` from `CQ_Rx` and `table#Hunters` from `Reply_Rx`, computes distance/bearing from reference grid EM48, and ranks by distance + SNR ordinal ranks (`priority_score` lower is better). No probability used yet. Contacts combined into `table#Contacts`.
+- **Distance/bearing calc:** Uses `geopy.distance.geodesic` (`geography/distance.py`) and simple bearing math; reference location is hardcoded EM48.
+- **UI consumption:** `app/app.py` Shiny app loads Kedro catalog; tabs render `Callers`, `Hunters`, `Contacts` via `table#*` datasets, filtered by date range. No access to inference outputs today.
+- **Data catalog:** `conf/base/catalog.yml` defines transformed tables in `data/02_transformed`, features in `03`, inference outputs in `05`; contact model artifacts stored under `data/04_models`.
+
+## Key questions (answers where known)
+- **Where to get probability values?** From `inference::table#ContactProbabilities` (SNR → p_mean and bounds).
+- **How Callers are defined?** Latest CQ per callsign from `CQ_Rx`, with `snr` from message.
+- **How priority currently computed?** Distance rank + SNR rank (descending) summed.
+- **Is probability per-callsign or global?** Global curve vs SNR; not caller-specific.
+- **Success label source?** Not set in code; unclear how success is derived from signoff join.
+
+## Architectural options considered
+- **Option A: Pipeline join & new priority column**
+  - Join `Callers` with `ContactProbabilities` on nearest/rounded `snr` to assign `p_contact` per caller; compute new `priority_score` using distance weighted by `p_contact`. Pros: consistent, cached dataset for UI; no extra UI logic. Cons: needs decision on interpolation and weighting formula; requires rerunning pipeline when model updates.
+- **Option B: UI-side weighting**
+  - Load `ContactProbabilities` in Shiny, map SNR → probability, compute priority on the fly. Pros: fast iteration without pipeline change; can swap formulas via UI. Cons: duplicates logic, harder to keep in sync with data versioning; heavier client computation for large tables.
+- **Option C: Hybrid**
+  - Pipeline stores `p_contact` per caller; UI chooses among multiple priority formulas (distance-only vs prob-weighted). Pros: flexibility for experiments. Cons: added UI complexity.
+
+## Potential gotchas
+- Missing/undefined `success` column in `fit_contact_model` input; need confirmation on label definition and encoding for binomial model.
+- Callers’ `snr` may be non-integer; probability table is integer -30..30—interpolation or rounding strategy required.
+- SNRs outside modeled range need a clamp/default.
+- Reference grid is fixed to EM48; if station grid changes, distance weighting must update.
+- Date-range filtering in UI pulls from `table#Callers`/`Hunters`; ensure prob/priorities align with same timestamp scope.
+- Hunters currently lack a probability model; rankings remain distance/SNR based unless extended.
+
+## Open questions
+- Exact weighting formula: distance * p_contact? distance_rank / p? log-weight? Should higher distance still dominate when probability is low?
+- Do we prefer pipeline-level computation (and persisted columns) or UI-layer computation?
+- How to handle non-integer or missing SNR values for callers?
+- What defines contact “success” for the model—presence of Signoff within a window? Needs to be reflected in features.
+- How frequently is the model retrained, and how should the UI react to updated inference outputs?
+- Should we display uncertainty (p_lower/p_upper) or only mean?
+- Any station-location variability (EM48 hardcoded) that should be parameterized?
+
+## Implementation status
+- Pipeline-side enrichment implemented:
+  - `active_callsigns` now loads `p_contact_model` and `p_contact_idata` artifacts.
+  - New node computes per-caller `p_contact` using the Bayesian logistic regression model and each caller's `snr`.
+  - New column `priority_score_prob` is computed as `distance_miles * p_contact` (lower is better).
+  - `table#Callers` carries `p_contact` and `priority_score_prob`, and these propagate into `table#Contacts` for caller rows.
+- UI integration:
+  - `Caller` and `Contacts` tables default-sort by `priority_score_prob` when available (falling back to `priority_score`).
+  - `Hunters` remain ranked by the existing distance/SNR-based `priority_score`; no probability model applied yet.
+
+## Recommended next steps for planning
+- Clarify/implement the `success` label in `prepare_attempted_contacts` to ensure the model is learning the intended outcome.
+

--- a/src/digi_dx/pipelines/active_callsigns/nodes.py
+++ b/src/digi_dx/pipelines/active_callsigns/nodes.py
@@ -202,7 +202,7 @@ def add_contact_probability(
 
 def combine_target_contacts(callers: pl.LazyFrame, hunters: pl.LazyFrame) -> pl.DataFrame:
     return (
-        pl.concat([callers, hunters], how="vertical")
+        pl.concat([callers, hunters], how="diagonal")
         .sort(["callsign", "timestamp"], descending=True)
         .unique("callsign", keep="first")
     )

--- a/src/digi_dx/pipelines/active_callsigns/nodes.py
+++ b/src/digi_dx/pipelines/active_callsigns/nodes.py
@@ -1,9 +1,7 @@
-"""
-This is a boilerplate pipeline 'active_callsigns'
-generated using Kedro 1.0.0
-"""
-
 import polars as pl
+import arviz as az
+import pandas as pd
+from typing import Any
 
 from digi_dx.geography import (
     calc_distance,
@@ -138,6 +136,68 @@ def add_priority(contacts: pl.LazyFrame) -> pl.LazyFrame:
         )
         .sort("priority_score")
     )
+
+
+def add_contact_probability(
+    callers: pl.LazyFrame,
+    model: Any,
+    idata: Any,
+) -> pl.LazyFrame:
+    """Add contact probability and probability-weighted priority score.
+
+    Uses the fitted Bayesian logistic regression contact model to compute
+    per-caller contact probabilities based on SNR, then multiplies by distance
+    to get a probability-weighted priority score. Lower scores are better.
+
+    Args:
+        callers: LazyFrame with at least snr and distance_miles columns, and
+            existing rank-based priority columns.
+        model: Fitted Bambi contact model (p_contact_model).
+        idata: ArviZ InferenceData from the fitted model (p_contact_idata).
+
+    Returns:
+        LazyFrame with added p_contact and priority_score_prob columns,
+        sorted by probability-weighted priority (ascending).
+    """
+    callers_df = callers.collect()
+
+    if callers_df.height == 0:
+        # Preserve empty LazyFrame and schema
+        return callers
+
+    # Build prediction data frame compatible with the contact model
+    prediction_data = pd.DataFrame(
+        {"snr_cq": callers_df["snr"].to_pandas()}
+    )
+
+    prediction = model.predict(idata, data=prediction_data, inplace=False)
+
+    posterior = (
+        az.extract(prediction, var_names="p")
+        .to_dataframe()
+        .reset_index()
+        .groupby("__obs__")
+        .agg(p_mean=("p", "mean"))
+        .reset_index(drop=True)
+    )
+
+    callers_df = callers_df.with_columns(
+        [
+            pl.Series(
+                name="p_contact",
+                values=posterior["p_mean"].to_numpy(),
+            ),
+        ]
+    ).with_columns(
+        (pl.col("distance_miles") * pl.col("p_contact")).alias(
+            "priority_score_prob"
+        )
+    )
+
+    # Sort by probability-weighted priority (lower is better)
+    callers_df = callers_df.sort("priority_score_prob")
+
+    return callers_df.lazy()
 
 
 def combine_target_contacts(callers: pl.LazyFrame, hunters: pl.LazyFrame) -> pl.DataFrame:

--- a/src/digi_dx/pipelines/active_callsigns/pipeline.py
+++ b/src/digi_dx/pipelines/active_callsigns/pipeline.py
@@ -1,10 +1,13 @@
-"""
-This is a boilerplate pipeline 'active_callsigns'
-generated using Kedro 1.0.0
-"""
-
 from kedro.pipeline import Node, Pipeline  # noqa
-from .nodes import convert_cq_to_callers, convert_reply_to_hunters, add_priority, combine_target_contacts
+
+from .nodes import (
+    add_contact_probability,
+    add_priority,
+    combine_target_contacts,
+    convert_cq_to_callers,
+    convert_reply_to_hunters,
+)
+
 
 def create_pipeline(**kwargs) -> Pipeline:
     return Pipeline(
@@ -12,27 +15,32 @@ def create_pipeline(**kwargs) -> Pipeline:
             Node(
                 convert_cq_to_callers,
                 inputs="table#CQ_Rx",
-                outputs="callers_raw"
+                outputs="callers_raw",
             ),
             Node(
                 add_priority,
                 inputs="callers_raw",
-                outputs="table#Callers"
+                outputs="callers_with_priority",
+            ),
+            Node(
+                add_contact_probability,
+                inputs=["callers_with_priority", "p_contact_model", "p_contact_idata"],
+                outputs="table#Callers",
             ),
             Node(
                 convert_reply_to_hunters,
                 inputs="table#Reply_Rx",
-                outputs="hunters_raw"
+                outputs="hunters_raw",
             ),
             Node(
                 add_priority,
                 inputs="hunters_raw",
-                outputs="table#Hunters"
+                outputs="table#Hunters",
             ),
             Node(
                 combine_target_contacts,
                 inputs=["table#Callers", "table#Hunters"],
-                outputs="table#Contacts"
+                outputs="table#Contacts",
             ),
         ]
     )

--- a/tests/pipelines/active_callsigns/test_pipeline.py
+++ b/tests/pipelines/active_callsigns/test_pipeline.py
@@ -1,9 +1,92 @@
-"""
-This is a boilerplate test file for pipeline 'active_callsigns'
-generated using Kedro 1.0.0.
-Please add your pipeline tests here.
+import numpy as np
+import pandas as pd
+import polars as pl
 
-Kedro recommends using `pytest` framework, more info about it can be found
-in the official documentation:
-https://docs.pytest.org/en/latest/getting-started.html
-"""
+from digi_dx.pipelines.active_callsigns.nodes import (
+    add_contact_probability,
+    add_priority,
+)
+from digi_dx.pipelines.p_contact.nodes import fit_contact_model
+
+
+def _build_test_contact_model():
+    """Create a small synthetic contact model for testing."""
+    attempted = pd.DataFrame(
+        {
+            "snr_cq": [-20, -10, 0, 10, 20],
+            "success": [0, 0, 0, 1, 1],
+            "attempts": [1, 1, 1, 1, 1],
+        }
+    )
+    model, idata = fit_contact_model(attempted)
+    return model, idata
+
+
+def test_add_contact_probability_adds_columns_and_priority():
+    model, idata = _build_test_contact_model()
+
+    callers = pl.DataFrame(
+        {
+            "timestamp": [0, 1, 2],
+            "frequency": [7.074, 7.074, 7.074],
+            "callsign": ["A", "B", "C"],
+            "grid": ["EM48", "EM48", "EM48"],
+            "snr": [-10.0, 0.0, 10.0],
+            "contact_role": ["caller", "caller", "caller"],
+            "latitude": [0.0, 0.0, 0.0],
+            "longitude": [0.0, 0.0, 0.0],
+            "distance_miles": [100.0, 200.0, 300.0],
+            "bearing_degrees": [0.0, 0.0, 0.0],
+        }
+    ).lazy()
+
+    callers_with_priority = add_priority(callers)
+    enriched = add_contact_probability(callers_with_priority, model, idata).collect()
+
+    # New columns are present
+    assert "p_contact" in enriched.columns
+    assert "priority_score_prob" in enriched.columns
+
+    # Probabilities are in [0, 1]
+    assert enriched["p_contact"].min() >= 0.0
+    assert enriched["p_contact"].max() <= 1.0
+
+    # Check that probability increases with SNR for this synthetic model
+    probs_by_callsign = dict(zip(enriched["callsign"], enriched["p_contact"]))
+    assert probs_by_callsign["A"] <= probs_by_callsign["B"] <= probs_by_callsign["C"]
+
+    # priority_score_prob should equal distance_miles * p_contact
+    expected_priority = enriched["distance_miles"] * enriched["p_contact"]
+    assert np.allclose(
+        enriched["priority_score_prob"].to_numpy(),
+        expected_priority.to_numpy(),
+        rtol=1e-6,
+    )
+
+
+def test_add_contact_probability_handles_empty_input():
+    model, idata = _build_test_contact_model()
+
+    empty_callers = pl.DataFrame(
+        {
+            "timestamp": pl.Series([], dtype=pl.Int64),
+            "frequency": pl.Series([], dtype=pl.Float64),
+            "callsign": pl.Series([], dtype=pl.String),
+            "grid": pl.Series([], dtype=pl.String),
+            "snr": pl.Series([], dtype=pl.Float64),
+            "contact_role": pl.Series([], dtype=pl.String),
+            "latitude": pl.Series([], dtype=pl.Float64),
+            "longitude": pl.Series([], dtype=pl.Float64),
+            "distance_miles": pl.Series([], dtype=pl.Float64),
+            "bearing_degrees": pl.Series([], dtype=pl.Float64),
+            "distance_rank": pl.Series([], dtype=pl.Float64),
+            "snr_rank": pl.Series([], dtype=pl.Float64),
+            "priority_score": pl.Series([], dtype=pl.Float64),
+        }
+    ).lazy()
+
+    enriched = add_contact_probability(empty_callers, model, idata).collect()
+
+    # Should remain empty and preserve columns
+    assert enriched.height == 0
+    assert "p_contact" not in enriched.columns or enriched["p_contact"].is_empty()


### PR DESCRIPTION
This is an AI-driven change to add in a prediction for prioritization. Basically this weights the distance to the station by the probability of contact, and as such priuoritizes contacts by their "expected value." This sets the stage so we can iterate on the `p_contact` model for callers -- as long as the final table has the `priority_score_prob` column, the UI will be happy.

Some of the changes annoy me, such as the conditional sorting of the contacts table. That was unnecessary, but the AI did it anyway and for the sake of velocity, I'll let that slide. I would like for us to do a major refactor of the UI in the near future anyway, so we can address it at that time.