### PR TITLE
refactor: extract OperatorController QSO automation engine (W2)

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -33,4 +33,4 @@ Simulated stations use callsigns from an ITU non-assignable prefix so a leaked d
 ## Flagged ambiguities
 
 - "'KTD5' is plan-local numbering — the demo-mode plan's KTD5 is 'demo is real-time; only verification scales,' not the similarly numbered item in the earlier engine-backend plan."
-- "'Engine' in conversation may mean the daemon's session orchestrator or the external modem binary; prefer Engine driver for the process boundary and Session for the orchestrated lifetime."
+- "'Engine' in conversation may mean the daemon's session orchestrator, the external modem binary, or the client-side 'QSO automation engine' (the OperatorController that drives QSO orchestration); prefer Engine driver for the process boundary, Session for the orchestrated lifetime, and 'automation engine'/OperatorController for the client-side QSO orchestration."

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,31 @@
+# Handoff — simulated engine & demo mode
+
+Scratch note. Delete when the branch merges.
+
+## State
+
+- **Branch:** `feat/slot-clock` (ahead of `main`; all of U1–U10 + review fixes committed)
+- **Plan:** `docs/plans/2026-07-13-001-feat-simulated-engine-demo-mode-plan.md`
+- **Done:** U1–U10. Untracked only: this `HANDOFF.md`.
+- **Gates green:** `npm test` (160), `npm run build`, `npm run typecheck`, `npm run smoke`, `npm run smoke:ui`
+
+## Verification commands
+
+```bash
+npm test && npm run build && npm run typecheck && npm run smoke && npm run smoke:ui
+```
+
+Screenshots: `artifacts/smoke-ui/` (gitignored). Residuals: `docs/residual-review-findings/feat-slot-clock.md`.
+
+## Remaining (human)
+
+1. **Open / push PR** when ready (not done from ce-work).
+2. **Hardware regression** at the radio box before any user-facing ship (Product Contract reachability).
+3. Soft R17 banners will appear on this PR’s own smoke runs (expected): CI shows a GitHub Actions warning annotation; exit stays 0.
+
+## Try demo
+
+```bash
+DIGI_DX_PORT=8911 DIGI_DX_CONFIG_PATH=/tmp/none.json npx tsx src/index.ts
+# start_session { demo: true }
+```

--- a/core/controller.ts
+++ b/core/controller.ts
@@ -69,7 +69,6 @@ export interface OperatorControllerDeps {
   log: QsoLogStore;
   state?: StateStore;
   token?: string;
-  now?: () => number; // injectable wall clock (test hook); defaults to Date.now
   onLog?: (level: LogLevel, text: string) => void; // activity-log sink
   // Optional ham-band namer for the dial-frequency log line. Injected (rather
   // than imported) so the engine keeps zero ui/ dependencies.
@@ -244,7 +243,6 @@ class OperatorControllerImpl implements OperatorController {
     this.token = deps.token;
     this.onLog = deps.onLog;
     this.bandForMHz = deps.bandForMHz;
-    void deps.now; // wall-now hook reserved; slot math uses the daemon clock
   }
 
   // --- state + change emission --------------------------------------------

--- a/core/controller.ts
+++ b/core/controller.ts
@@ -158,7 +158,7 @@ export interface OperatorController {
     callsign: string;
     grid: string;
     catMode: string;
-    catPort: string;
+    catPort: number;
   }): void;
   releaseControl(): void;
 
@@ -1056,7 +1056,7 @@ class OperatorControllerImpl implements OperatorController {
     callsign: string;
     grid: string;
     catMode: string;
-    catPort: string;
+    catPort: number;
   }): void {
     if (!this.ensureControl()) {
       return;

--- a/core/controller.ts
+++ b/core/controller.ts
@@ -1,0 +1,147 @@
+// OperatorController — the headless QSO automation engine (rebuild plan W2).
+//
+// This owns everything both reference clients used to orchestrate independently:
+// the QsoAutomation, the decode buffer, the slot-aligned scheduler, the survey,
+// control-claim state, dial frequency, and the worked-call/logging side effects.
+// The web server and the TUI become thin: they render `ControllerState` and route
+// input to the operator-action methods. All dependencies are injected, so the
+// engine runs identically inside a client process today or inside the daemon
+// later (rebuild plan option B) — a relocation, not a rewrite.
+//
+// U1 scaffolds the interface, state shape, deps, and change emitter. U2 ports the
+// web server's orchestration into the method bodies.
+
+import { DaemonClient } from "./daemon-client.js";
+import type { EngineKind } from "./protocol.js";
+import { SlotClock } from "./slot-clock.js";
+import type {
+  AutomationTx,
+  DecodeRecord,
+  QsoLogEntry,
+  QsoRecord,
+  TxSlot
+} from "./qso.js";
+
+// The daemon's public TX state, re-exported so clients need not reach into the
+// daemon protocol for it.
+export type TxState = "idle" | "pending" | "active";
+
+export type LogLevel = "info" | "warn" | "error" | "tx" | "qso";
+
+export interface SetupDeviceView {
+  id: number;
+  name: string;
+  defaultSampleRate: number | null;
+}
+
+// Persisted, engine-scoped QSO log. Wraps the on-disk JSONL writer/reader so the
+// controller never imports a client-side path helper directly (KTD3).
+export interface QsoLogStore {
+  append(entry: QsoLogEntry, engine: EngineKind): Promise<void>;
+  readAll(): Promise<QsoLogEntry[]>;
+}
+
+// Small persisted-state seam for the dial frequency (today's tui-state.json).
+export interface StateStore {
+  read(): Promise<{ dialFreqHz?: number | null }>;
+  write(patch: { dialFreqHz?: number | null }): Promise<void>;
+}
+
+export interface OperatorControllerDeps {
+  client: DaemonClient;
+  log: QsoLogStore;
+  state?: StateStore;
+  token?: string;
+  now?: () => number; // injectable wall clock (test hook); defaults to Date.now
+  onLog?: (level: LogLevel, text: string) => void; // activity-log sink
+}
+
+// The authoritative, framework-agnostic snapshot both clients render from. It
+// mirrors exactly what the web server's buildState() reads today, so the
+// view-model becomes a pure ControllerState -> StateMessage transform (KTD2).
+export interface ControllerState {
+  station: {
+    call: string;
+    grid: string;
+    dialFreqHz: number | null;
+    catConnected: boolean;
+    sessionActive: boolean;
+    controlHeld: boolean;
+    controlMine: boolean;
+    demo: boolean; // engineKind === "simulated"
+  };
+  setup: {
+    complete: boolean;
+    missing: string[];
+    devices: SetupDeviceView[];
+  };
+  tx: {
+    state: TxState;
+    enabled: boolean;
+    // The automation TX to surface: pending ?? active ?? scheduled.
+    displayTx: AutomationTx | null;
+    txingQsoId: string | null;
+  };
+  survey: {
+    active: boolean;
+    slot: TxSlot | null;
+    endSec: number;
+  };
+  af: {
+    value: number;
+    slot: TxSlot; // the slot we will transmit in (CQ row's slot, else manual)
+  };
+  qsos: {
+    callingCq: boolean;
+    active: QsoRecord[];
+    completed: QsoRecord[];
+  };
+  decodes: DecodeRecord[];
+  workedCalls: ReadonlySet<string>;
+  // The daemon's published slot clock, or null before the first status / after a
+  // disconnect. Clients derive countdowns and cycle math from it; they never
+  // invent slot timing from a local wall clock.
+  clock: SlotClock | null;
+}
+
+export type QsoActionName =
+  | "complete"
+  | "abandon"
+  | "resume"
+  | "retry"
+  | "prevStep"
+  | "nextStep"
+  | "moveUp"
+  | "moveDown";
+
+export interface OperatorController {
+  readonly state: ControllerState;
+  onChange(listener: (state: ControllerState) => void): () => void;
+
+  // Operator actions — mirror today's UI handlers.
+  setIdentity(call: string, grid: string): void;
+  setDialFreq(mhz: number | null): void;
+  setAf(af: number): void;
+  setSlot(slot: TxSlot): void;
+  callCq(slot?: TxSlot, identity?: { myCall?: string; myGrid?: string }): void;
+  stopCq(reason?: string): void;
+  replyToCall(call: string, identity?: { myCall?: string; myGrid?: string }): void;
+  qsoAction(id: string, action: QsoActionName): void;
+  survey(): void;
+  setTxEnabled(enabled: boolean): void;
+  haltTx(): void;
+  startSession(): void;
+  startDemo(): void;
+  stopSession(): void;
+  saveSetup(setup: {
+    deviceId: number;
+    callsign: string;
+    grid: string;
+    catMode: string;
+    catPort: string;
+  }): void;
+  releaseControl(): void;
+
+  start(): void; // subscribe to client events, seed worked-calls/dial-freq
+  dispose(): void; // clear timers, unsubscribe
+}

--- a/core/controller.ts
+++ b/core/controller.ts
@@ -11,16 +11,33 @@
 // U1 scaffolds the interface, state shape, deps, and change emitter. U2 ports the
 // web server's orchestration into the method bodies.
 
-import { DaemonClient } from "./daemon-client.js";
-import type { EngineKind } from "./protocol.js";
-import { SlotClock } from "./slot-clock.js";
+import type { DaemonClient } from "./daemon-client.js";
 import type {
-  AutomationTx,
-  DecodeRecord,
-  QsoLogEntry,
-  QsoRecord,
-  TxSlot
+  AudioDevicesMessage,
+  ConfigMessage,
+  DaemonCommand,
+  DaemonStatus,
+  DecodeEvent,
+  EngineKind,
+  ErrorMessage,
+  LogEvent,
+  TxEvent,
+  TxUpdateEvent
+} from "./protocol.js";
+import { SlotClock } from "./slot-clock.js";
+import {
+  QsoAutomation,
+  oppositeSlot,
+  slotFromTimestamp,
+  suggestClearAf,
+  type AutomationTx,
+  type DecodeRecord,
+  type QsoAutomationEvent,
+  type QsoLogEntry,
+  type QsoRecord,
+  type TxSlot
 } from "./qso.js";
+import { gridFrom, latestSlotAfs, senderOf } from "./view-model.js";
 
 // The daemon's public TX state, re-exported so clients need not reach into the
 // daemon protocol for it.
@@ -54,6 +71,9 @@ export interface OperatorControllerDeps {
   token?: string;
   now?: () => number; // injectable wall clock (test hook); defaults to Date.now
   onLog?: (level: LogLevel, text: string) => void; // activity-log sink
+  // Optional ham-band namer for the dial-frequency log line. Injected (rather
+  // than imported) so the engine keeps zero ui/ dependencies.
+  bandForMHz?: (mhz: number) => string | null;
 }
 
 // The authoritative, framework-agnostic snapshot both clients render from. It
@@ -144,4 +164,924 @@ export interface OperatorController {
 
   start(): void; // subscribe to client events, seed worked-calls/dial-freq
   dispose(): void; // clear timers, unsubscribe
+}
+
+// Slot survey: hold TX for one receive cycle of our TX parity so the (otherwise
+// deaf) TX slot can be observed, then suggest a clear frequency.
+const SURVEY_LO_HZ = 300;
+const SURVEY_HI_HZ = 2700;
+const SURVEY_DECODE_LAG_SECONDS = 5;
+// Arm this many virtual seconds before the slot opens, so the daemon has time to
+// hand the message to the engine. Virtual, so it scales with the clock.
+const AUTOMATION_LEAD_SECONDS = 2;
+
+export function createOperatorController(deps: OperatorControllerDeps): OperatorController {
+  return new OperatorControllerImpl(deps);
+}
+
+class OperatorControllerImpl implements OperatorController {
+  private readonly client: DaemonClient;
+  private readonly logStore: QsoLogStore;
+  private readonly stateStore?: StateStore;
+  private readonly token?: string;
+  private readonly onLog?: (level: LogLevel, text: string) => void;
+  private readonly bandForMHz?: (mhz: number) => string | null;
+
+  private readonly decodes: DecodeRecord[] = [];
+  // The automation is constructed before any clock arrives, so its timestamp
+  // source is a late-bound closure over the clock we adopt from the daemon. It
+  // throws rather than reaching for Date.now(): this is the one place that
+  // decides every logged QSO's timestamp, and a silent wall-time fallback would
+  // log a scaled QSO in the wrong time base. Safe because the daemon sends a
+  // status on connect, before any decode can arrive.
+  private readonly automation = new QsoAutomation(() => new Date(this.requireClock().now()));
+
+  private myCall = "";
+  private myGrid = "";
+  private dialFreqHz: number | null = null;
+
+  private controlHeld = false;
+  private controlMine = false;
+  private controlClaimPending = false;
+  private sessionActive = false;
+  private catConnected = false;
+  private configComplete = false;
+  private configMissing: string[] = [];
+  private setupDevices: SetupDeviceView[] = [];
+
+  private latestTxState: TxState = "idle";
+  private pendingAutomationTx: AutomationTx | null = null;
+  private activeAutomationTx: AutomationTx | null = null;
+  private scheduledAutomationTx: AutomationTx | null = null;
+  // The daemon is the authority on slot timing. We hold the clock it publishes
+  // and derive every slot decision from it. There is deliberately no wall-clock
+  // fallback: before the first status, and after a reconnect, we have no clock,
+  // and a silent Date.now() fallback is exactly the bug a scaled clock would hide.
+  private clock: SlotClock | null = null;
+  private engineKind: EngineKind = "ft8cat";
+
+  private automationTimer: ReturnType<typeof setTimeout> | null = null;
+  private txEnabled = true;
+
+  private currentAf = 1000;
+  private currentSlot: TxSlot = "even";
+
+  private readonly loggedQsoIds = new Set<string>();
+  private readonly workedCalls = new Set<string>();
+
+  private surveyActive = false;
+  private surveySlot: TxSlot | null = null;
+  private surveyEndSec = 0;
+  private surveyTimer: ReturnType<typeof setTimeout> | null = null;
+
+  private readonly listeners = new Set<(state: ControllerState) => void>();
+  private readonly unsubscribers: Array<() => void> = [];
+
+  constructor(deps: OperatorControllerDeps) {
+    this.client = deps.client;
+    this.logStore = deps.log;
+    this.stateStore = deps.state;
+    this.token = deps.token;
+    this.onLog = deps.onLog;
+    this.bandForMHz = deps.bandForMHz;
+    void deps.now; // wall-now hook reserved; slot math uses the daemon clock
+  }
+
+  // --- state + change emission --------------------------------------------
+
+  get state(): ControllerState {
+    const txingQsoId =
+      this.pendingAutomationTx?.qsoId ?? this.activeAutomationTx?.qsoId ?? null;
+    const displayTx =
+      this.pendingAutomationTx ?? this.activeAutomationTx ?? this.scheduledAutomationTx;
+    return {
+      station: {
+        call: this.myCall,
+        grid: this.myGrid,
+        dialFreqHz: this.dialFreqHz,
+        catConnected: this.catConnected,
+        sessionActive: this.sessionActive,
+        controlHeld: this.controlHeld,
+        controlMine: this.controlMine,
+        demo: this.engineKind === "simulated"
+      },
+      setup: {
+        complete: this.configComplete,
+        missing: this.configMissing,
+        devices: this.setupDevices
+      },
+      tx: {
+        state: this.latestTxState,
+        enabled: this.txEnabled,
+        displayTx,
+        txingQsoId
+      },
+      survey: {
+        active: this.surveyActive,
+        slot: this.surveySlot,
+        endSec: this.surveyEndSec
+      },
+      af: { value: this.currentAf, slot: this.currentTxSlot() },
+      qsos: {
+        callingCq: this.automation.isCallingCq(),
+        active: this.automation.qsos.filter((qso) => qso.status !== "complete"),
+        completed: this.automation.qsos.filter((qso) => qso.status === "complete")
+      },
+      decodes: this.decodes,
+      workedCalls: this.workedCalls,
+      clock: this.clock
+    };
+  }
+
+  onChange(listener: (state: ControllerState) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private emit(): void {
+    if (this.listeners.size === 0) {
+      return;
+    }
+    const snapshot = this.state;
+    for (const listener of this.listeners) {
+      listener(snapshot);
+    }
+  }
+
+  private appendLog(level: LogLevel, text: string): void {
+    this.onLog?.(level, text);
+    this.emit();
+  }
+
+  private requireClock(): SlotClock {
+    if (!this.clock) {
+      throw new Error("slot clock unavailable: no status received from the daemon yet");
+    }
+    return this.clock;
+  }
+
+  private daemonSend(command: DaemonCommand): boolean {
+    if (!this.client.send(command)) {
+      this.appendLog("warn", "daemon not connected");
+      return false;
+    }
+    return true;
+  }
+
+  // --- lifecycle -----------------------------------------------------------
+
+  start(): void {
+    void this.seedPersistedState();
+    this.subscribe();
+    this.client.connect();
+  }
+
+  dispose(): void {
+    this.clearAutomationTimer();
+    if (this.surveyTimer) {
+      clearTimeout(this.surveyTimer);
+      this.surveyTimer = null;
+    }
+    for (const off of this.unsubscribers.splice(0)) {
+      off();
+    }
+    this.listeners.clear();
+  }
+
+  private async seedPersistedState(): Promise<void> {
+    if (this.stateStore) {
+      try {
+        const persisted = await this.stateStore.read();
+        if (persisted.dialFreqHz != null) {
+          this.dialFreqHz = persisted.dialFreqHz;
+          this.emit();
+        }
+      } catch {
+        // Non-fatal: start without a restored dial frequency.
+      }
+    }
+    try {
+      for (const entry of await this.logStore.readAll()) {
+        if (entry.theirCall) {
+          this.workedCalls.add(entry.theirCall.toUpperCase());
+        }
+      }
+    } catch {
+      // Non-fatal: start with an empty worked-call set.
+    }
+  }
+
+  private subscribe(): void {
+    type AnyHandler = (...args: never[]) => void;
+    // The typed EventEmitter's per-event overloads don't resolve through a
+    // generic helper, so erase to a plain (event, handler) shape here; each
+    // handler is written with its concrete payload type below.
+    const emitterOn = this.client.on.bind(this.client) as unknown as (e: string, h: AnyHandler) => void;
+    const emitterOff = this.client.off.bind(this.client) as unknown as (e: string, h: AnyHandler) => void;
+    const add = (event: string, handler: AnyHandler): void => {
+      emitterOn(event, handler);
+      this.unsubscribers.push(() => emitterOff(event, handler));
+    };
+
+    add("open", (() => {
+      this.appendLog("info", "connected to daemon");
+      this.daemonSend({ type: "get_config" });
+      this.daemonSend({ type: "list_audio_devices" });
+    }) as AnyHandler);
+    add("close", (() => this.onDaemonClose()) as AnyHandler);
+    add("status", ((msg: DaemonStatus) => this.onStatus(msg)) as AnyHandler);
+    add("decode", ((msg: DecodeEvent) => this.onDecode(msg)) as AnyHandler);
+    add("tx", ((msg: TxEvent) => this.onTx(msg)) as AnyHandler);
+    add("tx_update", ((msg: TxUpdateEvent) => this.updateTxState(msg.state)) as AnyHandler);
+    add("log", ((msg: LogEvent) => this.appendLog(msg.level, `[daemon] ${msg.message}`)) as AnyHandler);
+    add("daemonError", ((msg: ErrorMessage) => this.onDaemonError(msg)) as AnyHandler);
+    add("config", ((msg: ConfigMessage) => this.onConfig(msg)) as AnyHandler);
+    add("audio_devices", ((msg: AudioDevicesMessage) => this.onAudioDevices(msg)) as AnyHandler);
+  }
+
+  // --- daemon events -------------------------------------------------------
+
+  private onDaemonClose(): void {
+    this.controlHeld = false;
+    this.controlMine = false;
+    this.controlClaimPending = false;
+    this.sessionActive = false;
+    this.latestTxState = "idle";
+    // Drop the daemon's clock on disconnect: there is no authoritative time base
+    // until the next status arrives. Leaving a scaled clock (or an armed timer)
+    // across reconnect is exactly the demo->real footgun.
+    this.clock = null;
+    this.engineKind = "ft8cat";
+    this.clearAutomationState("daemon disconnected");
+    this.appendLog("warn", "daemon connection closed; retrying in 2s");
+  }
+
+  private onStatus(msg: DaemonStatus): void {
+    const { session, tx, control } = msg;
+    const hadControl = this.controlMine;
+    const previousActive = this.sessionActive;
+    const previousKind = this.engineKind;
+    const previousClock = this.clock;
+
+    // Adopt the daemon's clock. Any field change (not just scale) can move the
+    // next boundary, so re-arm rather than leaving a timer at a stale anchor.
+    const clockDirty =
+      previousClock === null ||
+      previousClock.spec.epochMs !== msg.clock.epochMs ||
+      previousClock.spec.anchorWallMs !== msg.clock.anchorWallMs ||
+      previousClock.spec.slotMs !== msg.clock.slotMs ||
+      previousClock.spec.scale !== msg.clock.scale;
+    this.clock = new SlotClock(msg.clock);
+    this.engineKind = msg.engine;
+
+    if (session.callsign !== null) {
+      this.myCall = session.callsign;
+    }
+    if (session.grid !== null) {
+      this.myGrid = session.grid;
+    }
+    this.controlHeld = control.held;
+    this.controlMine = control.byThisClient;
+    if (this.controlMine || !this.controlHeld) {
+      this.controlClaimPending = false;
+    }
+    this.sessionActive = session.active;
+    this.catConnected = session.catConnected;
+
+    const sessionEnded = previousActive && !session.active;
+    const kindChanged = previousKind !== msg.engine;
+    // Demo->real at scale 1 never trips a scale-only dirty check. Clear in-flight
+    // QSOs so leftover QQ0DEMO CQs cannot key the live radio or land in the real
+    // QSO log when they complete under the new engine.
+    if (sessionEnded || kindChanged) {
+      this.clearAutomationState(sessionEnded ? "session stopped" : "engine changed");
+    } else if (clockDirty) {
+      this.clearAutomationTimer();
+    }
+
+    this.updateTxState(tx.state);
+
+    if (
+      this.sessionActive &&
+      ((!hadControl && this.controlMine) || clockDirty || (kindChanged && !sessionEnded))
+    ) {
+      this.scheduleAutomation();
+    }
+    this.emit();
+  }
+
+  private onDecode(msg: DecodeEvent): void {
+    const record: DecodeRecord = {
+      ts: msg.ts,
+      snr: msg.snr,
+      dt: msg.dt,
+      af: msg.af,
+      message: msg.message
+    };
+    this.decodes.push(record);
+    if (this.decodes.length > 2000) {
+      this.decodes.splice(0, this.decodes.length - 2000);
+    }
+    const events = this.automation.handleDecode(record, this.myCall, this.myGrid);
+    if (events.length > 0) {
+      this.handleQsoEvents(events);
+      this.cancelSurvey("answering caller");
+      this.scheduleAutomation();
+    }
+    this.emit();
+  }
+
+  private onTx(msg: TxEvent): void {
+    this.appendLog("tx", `[tx] af=${msg.af} ${msg.message}`);
+    const result = this.automation.confirmTransmission(this.pendingAutomationTx, {
+      ts: msg.ts,
+      af: msg.af,
+      message: msg.message
+    });
+    if (result.matched) {
+      this.activeAutomationTx = this.pendingAutomationTx;
+      this.pendingAutomationTx = null;
+    }
+    if (result.events.length > 0) {
+      this.handleQsoEvents(result.events);
+    }
+    this.scheduleAutomation();
+  }
+
+  private onDaemonError(msg: ErrorMessage): void {
+    if (msg.code === "CONTROL_REQUIRED" || msg.code === "CONTROL_UNAVAILABLE") {
+      this.controlClaimPending = false;
+      this.appendLog("warn", "control is held by another client");
+    } else {
+      this.appendLog("error", `[error] ${msg.code}: ${msg.message}`);
+    }
+    if (this.pendingAutomationTx) {
+      this.pendingAutomationTx = null;
+      this.activeAutomationTx = null;
+      this.scheduledAutomationTx = null;
+      this.scheduleAutomation();
+    }
+  }
+
+  private onConfig(msg: ConfigMessage): void {
+    this.configComplete = msg.complete;
+    this.configMissing = msg.missing ?? [];
+    if (msg.session?.callsign) {
+      this.myCall = msg.session.callsign;
+    }
+    if (msg.session?.grid) {
+      this.myGrid = msg.session.grid;
+    }
+    this.appendLog("info", `[config] complete=${msg.complete}`);
+    this.emit();
+  }
+
+  private onAudioDevices(msg: AudioDevicesMessage): void {
+    this.setupDevices = msg.devices.map((device) => ({
+      id: device.id,
+      name: device.name,
+      defaultSampleRate: device.defaultSampleRate ?? null
+    }));
+    this.emit();
+  }
+
+  // --- QSO event handling / logging ---------------------------------------
+
+  private handleQsoEvents(events: QsoAutomationEvent[]): void {
+    for (const event of events) {
+      switch (event.type) {
+        case "qso_created":
+          this.appendLog("qso", `[qso] created ${event.qso.theirCall ?? "CQ"}`);
+          break;
+        case "qso_updated":
+          this.appendLog("qso", `[qso] ${event.qso.theirCall} ${event.previousStep} -> ${event.qso.step}`);
+          break;
+        case "qso_completed":
+          this.appendLog("qso", `[qso] complete ${event.qso.theirCall ?? "CQ"} (${event.reason})`);
+          void this.logCompletedQso(event.qso, event.reason);
+          break;
+        case "qso_timed_out":
+          this.appendLog("qso", `[qso] timed out ${event.qso.theirCall ?? "CQ"} step=${event.qso.step}`);
+          break;
+        case "cq_stopped":
+          this.appendLog("qso", "[qso] CQ stopped after reply");
+          break;
+      }
+    }
+    this.emit();
+  }
+
+  private async logCompletedQso(qso: QsoRecord, reason: string): Promise<void> {
+    if (this.loggedQsoIds.has(qso.id)) {
+      return;
+    }
+    const entry = this.automation.toLogEntry(qso, reason, this.dialFreqHz);
+    if (!entry) {
+      return;
+    }
+    this.loggedQsoIds.add(qso.id);
+    try {
+      await this.logStore.append(entry, this.engineKind);
+      this.workedCalls.add(entry.theirCall.toUpperCase());
+      this.appendLog("info", `[qso-log] wrote ${entry.theirCall}${this.dialFreqHz ? "" : " (no freq set)"}`);
+    } catch (error) {
+      this.loggedQsoIds.delete(qso.id);
+      this.appendLog("error", `[qso-log error] ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  // --- scheduler -----------------------------------------------------------
+
+  // The slot we transmit in: the active CQ row's slot, else the manual slot.
+  private currentTxSlot(): TxSlot {
+    const cq = this.automation.qsos.find(
+      (qso) => qso.kind === "calling-cq" && qso.status === "active"
+    );
+    return cq ? cq.nextSlot : this.currentSlot;
+  }
+
+  private currentAfOrNull(): number | null {
+    if (!Number.isInteger(this.currentAf) || this.currentAf < 200 || this.currentAf > 3000) {
+      return null;
+    }
+    return this.currentAf;
+  }
+
+  private clearAutomationTimer(): void {
+    if (this.automationTimer) {
+      clearTimeout(this.automationTimer);
+      this.automationTimer = null;
+    }
+    this.scheduledAutomationTx = null;
+  }
+
+  private clearAutomationState(_reason: string): void {
+    this.clearAutomationTimer();
+    if (this.surveyActive) {
+      this.cancelSurvey("session boundary");
+    }
+    this.automation.qsos.splice(0);
+    this.pendingAutomationTx = null;
+    this.activeAutomationTx = null;
+    this.scheduledAutomationTx = null;
+  }
+
+  // Re-arm automation on the falling edge of "active" (a transmission finished),
+  // or on a genuine "idle" (e.g. after cancel). The daemon rests in "pending"
+  // after a TX, so we never rely on seeing "idle" to resume.
+  private updateTxState(next: TxState): void {
+    const wasActive = this.latestTxState === "active";
+    this.latestTxState = next;
+    if (wasActive && next !== "active") {
+      this.activeAutomationTx = null;
+    }
+    if (this.surveyActive || next === "active") {
+      return;
+    }
+    if (wasActive || next === "idle") {
+      this.scheduleAutomation();
+    }
+  }
+
+  private scheduleAutomation(): void {
+    this.clearAutomationTimer();
+
+    if (!this.sessionActive || this.surveyActive || !this.txEnabled || this.latestTxState === "active") {
+      this.emit();
+      return;
+    }
+
+    const af = this.currentAfOrNull();
+    if (af === null) {
+      this.emit();
+      return;
+    }
+
+    const tx = this.automation.nextTransmission(af);
+    if (!tx) {
+      this.emit();
+      return;
+    }
+
+    this.scheduledAutomationTx = tx;
+    if (!this.ensureAutomationControl()) {
+      this.emit();
+      return;
+    }
+
+    if (!this.clock) {
+      this.appendLog("warn", "[automation] paused: awaiting the slot clock from the daemon");
+      this.emit();
+      return;
+    }
+
+    // Arm two virtual seconds before the slot opens. The lead is a virtual
+    // quantity, so it scales with everything else; the clock converts it to the
+    // wall delay this setTimeout actually needs.
+    const delayMs = this.clock.wallDelayUntilSlot(tx.intent.slot, AUTOMATION_LEAD_SECONDS);
+    this.automationTimer = setTimeout(() => this.sendAutomatedTx(tx), delayMs);
+    this.emit();
+  }
+
+  private sendAutomatedTx(tx: AutomationTx): void {
+    this.automationTimer = null;
+    this.scheduledAutomationTx = null;
+    if (!this.sessionActive || this.surveyActive || !this.txEnabled || this.latestTxState === "active") {
+      return;
+    }
+    const af = this.currentAfOrNull();
+    if (af === null) {
+      this.appendLog("warn", "automation paused: invalid AF");
+      return;
+    }
+    if (!this.ensureAutomationControl()) {
+      this.scheduledAutomationTx = tx;
+      this.emit();
+      return;
+    }
+    const refreshed: AutomationTx = { ...tx, intent: { ...tx.intent, af } };
+    this.pendingAutomationTx = refreshed;
+    this.daemonSend({ type: "transmit", ...refreshed.intent });
+    this.emit();
+  }
+
+  // --- slot survey ---------------------------------------------------------
+
+  private startSurvey(): void {
+    if (this.surveyActive) {
+      return;
+    }
+    const slot = this.currentTxSlot();
+    this.surveyActive = true;
+    this.surveySlot = slot;
+
+    this.clearAutomationTimer();
+    if (this.pendingAutomationTx) {
+      this.daemonSend({ type: "cancel_transmit" });
+      this.pendingAutomationTx = null;
+    }
+    this.activeAutomationTx = null;
+    this.scheduledAutomationTx = null;
+
+    if (!this.clock) {
+      this.appendLog("warn", "[survey] unavailable: awaiting the slot clock from the daemon");
+      this.surveyActive = false;
+      this.emit();
+      return;
+    }
+
+    // Hold TX for one whole slot past the boundary, plus decode latency. That is
+    // a negative offset -- we wait past the slot rather than arming before it --
+    // and the slot length comes from the clock, never a literal 15.
+    const slotSeconds = this.clock.spec.slotMs / 1000;
+    const pastBoundary = slotSeconds + SURVEY_DECODE_LAG_SECONDS;
+    const delaySec = this.clock.secondsUntilSlot(slot) + pastBoundary;
+    // surveyEndSec is a rendered deadline, not a delay, so it lives in the
+    // clock's virtual base -- the same base the countdown is compared against.
+    this.surveyEndSec = this.clock.virtualDeadlineAfter(delaySec);
+    this.appendLog("info", `[survey] holding TX ~${delaySec}s to listen on the ${slot} slot`);
+    if (this.surveyTimer) {
+      clearTimeout(this.surveyTimer);
+    }
+    this.surveyTimer = setTimeout(() => this.finishSurvey(), this.clock.wallDelayUntilSlot(slot, -pastBoundary));
+    this.emit();
+  }
+
+  private finishSurvey(): void {
+    this.surveyTimer = null;
+    const slot = this.surveySlot;
+    this.surveyActive = false;
+    this.surveySlot = null;
+    if (slot) {
+      const occupied = latestSlotAfs(this.decodes, slot);
+      const suggestion = suggestClearAf(occupied, SURVEY_LO_HZ, SURVEY_HI_HZ);
+      this.currentAf = suggestion;
+      this.appendLog("info", `[survey] ${slot} slot updated, clear@${suggestion}Hz (${occupied.length} sigs)`);
+    }
+    this.scheduleAutomation();
+  }
+
+  private cancelSurvey(reason: string): void {
+    if (!this.surveyActive) {
+      return;
+    }
+    if (this.surveyTimer) {
+      clearTimeout(this.surveyTimer);
+      this.surveyTimer = null;
+    }
+    this.surveyActive = false;
+    this.surveySlot = null;
+    this.appendLog("info", `[survey] aborted (${reason})`);
+  }
+
+  // --- control -------------------------------------------------------------
+
+  private ensureControl(): boolean {
+    if (this.controlMine) {
+      return true;
+    }
+    if (this.controlHeld) {
+      this.appendLog("warn", "you do not have control (another client holds it)");
+      return false;
+    }
+    return this.daemonSend({ type: "claim_control", ...(this.token ? { token: this.token } : {}) });
+  }
+
+  private ensureAutomationControl(): boolean {
+    if (this.controlMine) {
+      return true;
+    }
+    if (this.controlHeld) {
+      this.appendLog("warn", "automation paused: another client has control");
+      return false;
+    }
+    if (
+      !this.controlClaimPending &&
+      this.daemonSend({ type: "claim_control", ...(this.token ? { token: this.token } : {}) })
+    ) {
+      this.controlClaimPending = true;
+      this.appendLog("info", "[control] claiming daemon control for automation");
+    }
+    return false;
+  }
+
+  private ensureIdentity(): boolean {
+    if (!this.myCall || !this.myGrid) {
+      this.appendLog("warn", "automation requires a callsign and grid");
+      return false;
+    }
+    if (!this.clock) {
+      this.appendLog("warn", "automation paused: awaiting the slot clock from the daemon");
+      return false;
+    }
+    return true;
+  }
+
+  private applyOptionalIdentity(identity?: { myCall?: string; myGrid?: string }): void {
+    if (identity && typeof identity.myCall === "string" && typeof identity.myGrid === "string") {
+      const nextCall = identity.myCall.trim().toUpperCase();
+      const nextGrid = identity.myGrid.trim().toUpperCase();
+      if (nextCall || nextGrid) {
+        this.myCall = nextCall;
+        this.myGrid = nextGrid;
+      }
+    }
+  }
+
+  private findLastDecodeFrom(call: string): DecodeRecord | null {
+    for (let index = this.decodes.length - 1; index >= 0; index--) {
+      if (senderOf(this.decodes[index]!.message) === call) {
+        return this.decodes[index]!;
+      }
+    }
+    return null;
+  }
+
+  // --- operator actions ----------------------------------------------------
+
+  setIdentity(call: string, grid: string): void {
+    this.myCall = call.trim().toUpperCase();
+    this.myGrid = grid.trim().toUpperCase();
+    this.appendLog("info", `[identity] ${this.myCall} ${this.myGrid}`);
+    this.emit();
+  }
+
+  setDialFreq(mhz: number | null): void {
+    if (mhz === null) {
+      this.dialFreqHz = null;
+    } else if (!Number.isFinite(mhz) || mhz <= 0) {
+      this.appendLog("warn", "freq: enter a positive frequency in MHz (e.g. 14.074)");
+      return;
+    } else {
+      this.dialFreqHz = Math.round(mhz * 1e6);
+      const band = this.bandForMHz?.(mhz) ?? null;
+      this.appendLog("info", `[freq] dial = ${mhz.toFixed(3)} MHz${band ? ` (${band})` : " (out of ham band?)"}`);
+    }
+    void this.stateStore
+      ?.write({ dialFreqHz: this.dialFreqHz })
+      .catch((error) =>
+        this.appendLog("error", `[state error] ${error instanceof Error ? error.message : String(error)}`)
+      );
+    this.emit();
+  }
+
+  setAf(af: number): void {
+    if (Number.isInteger(af)) {
+      this.currentAf = af;
+      this.scheduleAutomation();
+    }
+  }
+
+  setSlot(slot: TxSlot): void {
+    this.currentSlot = slot;
+    const cq = this.automation.qsos.find(
+      (qso) => qso.kind === "calling-cq" && qso.status === "active"
+    );
+    if (cq) {
+      cq.nextSlot = slot;
+      cq.updatedAt = new Date().toISOString();
+    }
+    this.scheduleAutomation();
+  }
+
+  callCq(slot?: TxSlot, identity?: { myCall?: string; myGrid?: string }): void {
+    this.applyOptionalIdentity(identity);
+    if (!this.ensureIdentity()) {
+      return;
+    }
+    if (this.automation.isCallingCq()) {
+      this.stopCq("operator stopped CQ");
+      return;
+    }
+    if (slot) {
+      this.currentSlot = slot;
+    }
+    this.automation.createCq(this.myCall, this.myGrid, slot ?? this.currentSlot, "top");
+    this.appendLog("qso", "[qso] calling CQ");
+    this.scheduleAutomation();
+  }
+
+  stopCq(reason = "operator stopped CQ"): void {
+    const cq = this.automation.qsos.find(
+      (qso) => qso.kind === "calling-cq" && qso.status === "active"
+    );
+    if (!cq) {
+      return;
+    }
+
+    const shouldCancelDaemonTx =
+      this.pendingAutomationTx?.qsoId === cq.id || this.activeAutomationTx?.qsoId === cq.id;
+
+    this.automation.abandon(cq.id);
+    if (this.scheduledAutomationTx?.qsoId === cq.id) {
+      this.clearAutomationTimer();
+    }
+    if (this.pendingAutomationTx?.qsoId === cq.id) {
+      this.pendingAutomationTx = null;
+    }
+    if (this.activeAutomationTx?.qsoId === cq.id) {
+      this.activeAutomationTx = null;
+    }
+    if (shouldCancelDaemonTx) {
+      this.daemonSend({ type: "cancel_transmit" });
+    }
+    this.appendLog("qso", `[qso] ${reason}`);
+    this.scheduleAutomation();
+  }
+
+  replyToCall(rawCall: string, identity?: { myCall?: string; myGrid?: string }): void {
+    this.applyOptionalIdentity(identity);
+    if (!this.ensureIdentity()) {
+      return;
+    }
+    const call = rawCall.trim().toUpperCase();
+    if (!/^[A-Z0-9/]{2,}$/.test(call)) {
+      this.appendLog("warn", `'${call}' is not a valid callsign`);
+      return;
+    }
+    const existing = this.automation.qsos.find(
+      (qso) => qso.kind === "standard" && qso.theirCall === call && qso.status !== "complete"
+    );
+    if (existing) {
+      this.appendLog("info", `QSO already exists for ${call}`);
+      return;
+    }
+    const last = this.findLastDecodeFrom(call);
+    const nextSlot = last ? oppositeSlot(slotFromTimestamp(last.ts)) : this.currentSlot;
+    const theirGrid = last ? gridFrom(last.message) : null;
+    const qso = this.automation.createReplyToCall(call, this.myCall, this.myGrid, nextSlot, theirGrid, "top");
+    this.appendLog("qso", `[qso] reply to ${qso.theirCall}`);
+    this.scheduleAutomation();
+  }
+
+  qsoAction(id: string, action: QsoActionName): void {
+    switch (action) {
+      case "complete":
+        this.handleQsoEvents(this.automation.complete(id));
+        break;
+      case "abandon":
+        this.automation.abandon(id);
+        break;
+      case "resume":
+        this.automation.resume(id);
+        break;
+      case "retry":
+        this.automation.resetAttempts(id);
+        break;
+      case "prevStep":
+        this.automation.previousStep(id);
+        break;
+      case "nextStep":
+        this.automation.nextStep(id);
+        break;
+      case "moveUp":
+        this.automation.move(id, -1);
+        break;
+      case "moveDown":
+        this.automation.move(id, 1);
+        break;
+      default:
+        this.appendLog("warn", `unknown qso action '${String(action)}'`);
+        return;
+    }
+    this.scheduleAutomation();
+  }
+
+  survey(): void {
+    this.startSurvey();
+  }
+
+  setTxEnabled(enabled: boolean): void {
+    this.txEnabled = enabled;
+    if (!enabled) {
+      this.clearAutomationTimer();
+      this.appendLog("info", "[tx] disabled — current transmission will finish");
+    } else {
+      // Resuming re-activates anything paused by a prior halt.
+      for (const qso of this.automation.qsos) {
+        if (qso.status === "paused") {
+          this.automation.resume(qso.id);
+        }
+      }
+      this.appendLog("info", "[tx] enabled");
+      this.scheduleAutomation();
+    }
+    this.emit();
+  }
+
+  haltTx(): void {
+    this.daemonSend({ type: "cancel_transmit" });
+    this.cancelSurvey("halted");
+    this.pendingAutomationTx = null;
+    this.activeAutomationTx = null;
+    this.scheduledAutomationTx = null;
+    this.clearAutomationTimer();
+    this.txEnabled = false;
+    this.automation.pauseAll("halted");
+    this.appendLog("warn", "[tx] halted by operator");
+    this.emit();
+  }
+
+  startSession(): void {
+    if (!this.ensureControl()) {
+      return;
+    }
+    if (!this.configComplete) {
+      this.appendLog("warn", "complete station setup before starting a session");
+      this.emit();
+      return;
+    }
+    this.daemonSend({ type: "start_session" });
+  }
+
+  startDemo(): void {
+    if (!this.ensureControl()) {
+      return;
+    }
+    // No configComplete guard: the whole point is that a user with no radio has
+    // no config to satisfy it with. The daemon synthesizes a demo identity.
+    this.appendLog("info", "[demo] starting on the simulated engine — nothing is transmitted");
+    this.daemonSend({ type: "start_session", demo: true });
+  }
+
+  stopSession(): void {
+    if (!this.ensureControl()) {
+      return;
+    }
+    this.daemonSend({ type: "stop_session" });
+  }
+
+  saveSetup(setup: {
+    deviceId: number;
+    callsign: string;
+    grid: string;
+    catMode: string;
+    catPort: string;
+  }): void {
+    if (!this.ensureControl()) {
+      return;
+    }
+    if (this.sessionActive) {
+      this.appendLog("warn", "cannot save setup while a session is active");
+      return;
+    }
+    this.daemonSend({
+      type: "save_config",
+      session: {
+        mode: "FT8",
+        device: { id: setup.deviceId },
+        callsign: setup.callsign,
+        grid: setup.grid,
+        cat: { mode: setup.catMode, port: setup.catPort }
+      }
+    });
+  }
+
+  releaseControl(): void {
+    if (!this.controlMine) {
+      this.appendLog("warn", "control is not held by this client");
+      return;
+    }
+    this.daemonSend({ type: "release_control" });
+  }
 }

--- a/core/view-model.ts
+++ b/core/view-model.ts
@@ -1,7 +1,12 @@
 // Pure, framework-agnostic helpers that turn raw controller state (decodes, QSO
-// records, TX state) into the browser view-model. Kept free of I/O and timers so
-// they can be unit-tested in isolation (test/web-view-model.test.ts); the server
-// (ui/web/server.ts) supplies the live state and the browser renders the result.
+// records, TX state) into a client view-model. Kept free of I/O and timers so
+// they can be unit-tested in isolation (test/view-model.test.ts). Both reference
+// clients render from these: the web server maps the result into its StateMessage
+// wire shape, and the TUI renders the same builders with blessed.
+//
+// These view types live in core (not ui/web/protocol.ts) so the module depends
+// only on core/qso.ts and core/slot-clock.ts — the isolation the rebuild plan's
+// W2 requires. ui/web/protocol.ts re-exports them for the browser wire contract.
 
 import {
   messageForQso,
@@ -11,21 +16,103 @@ import {
   type AutomationTx,
   type DecodeRecord,
   type QsoRecord,
+  type QsoStep,
   type TxSlot
-} from "../../core/qso.js";
-import { FT8_SLOT_MS, type SlotClock } from "../../core/slot-clock.js";
+} from "./qso.js";
+import { FT8_SLOT_MS, type SlotClock } from "./slot-clock.js";
+import type { TxPublicState } from "./protocol.js";
 
 const SLOT_SECONDS = FT8_SLOT_MS / 1000;
-import type {
-  ActiveQsoView,
-  CompletedQsoView,
-  CycleView,
-  DecodeKind,
-  DecodeView,
-  NowView,
-  RosterEntryView,
-  TxState
-} from "./protocol.js";
+
+// The daemon's TX state, shared by the view-model and the browser wire contract.
+export type TxState = TxPublicState;
+
+// How a decoded/heard station is coloured in the band panel and rosters.
+//  - "reply"  : the message mentions our callsign (someone answering us)
+//  - "qso"    : the sender matches an active standard QSO (carries its colour)
+//  - "worked" : the sender is already in the QSO log
+//  - "normal" : everything else
+export type DecodeKind = "reply" | "qso" | "worked" | "normal";
+
+export interface NowView {
+  txState: TxState;
+  txEnabled: boolean;
+  af: number | null;
+  slot: TxSlot | null;
+  message: string | null;
+  surveyActive: boolean;
+  surveySlot: TxSlot | null;
+  surveyEndSec: number;
+}
+
+export interface DecodeView {
+  ts: number;
+  snr: number;
+  af: number;
+  message: string;
+  from: string | null;
+  grid: string | null;
+  // Which slot this decode landed in, and the start of its cycle -- both
+  // computed here. The browser cannot import core/slot-clock.ts (it is a plain
+  // script with no build step), so it is never asked to derive slot math itself.
+  slot: TxSlot;
+  cycleStart: number;
+  kind: DecodeKind;
+  color?: string;
+}
+
+export interface CycleView {
+  parity: TxSlot;
+  // The wall instant of the next slot boundary, already scale-corrected. The
+  // browser counts down to it against its own (skew-corrected) wall clock, with
+  // no scale factor and no 15-second constant anywhere in it. Null before the
+  // daemon has published a clock -- render a neutral countdown, not a wrong one.
+  nextBoundaryWallMs: number | null;
+  // How long a slot lasts in wall time at the current scale -- what the browser
+  // needs to render the cycle progress bar without knowing the scale.
+  slotWallMs: number | null;
+  // How long a slot lasts in FT8 terms (15s). The countdown is rendered in these
+  // units at any scale, because an operator reasons in FT8 seconds.
+  slotSeconds: number | null;
+}
+
+export interface RosterEntryView {
+  call: string;
+  grid: string | null;
+  snr: number;
+  ageSec: number;
+  af: number;
+  kind: DecodeKind;
+  color?: string;
+}
+
+export interface ActiveQsoView {
+  id: string;
+  call: string | null;
+  grid: string | null;
+  priority: number;
+  kind: "hunted" | "caller";
+  stepKey: QsoStep;
+  status: string;
+  attempts: number;
+  slot: TxSlot;
+  heardAgoSec: number | null;
+  lastRx: string | null;
+  nextTx: string | null;
+  txing: boolean;
+  note: string | null;
+  color: string;
+}
+
+export interface CompletedQsoView {
+  id: string;
+  call: string | null;
+  grid: string | null;
+  sentReport: string | null;
+  receivedReport: string | null;
+  slot: TxSlot | null;
+  time: string;
+}
 
 // Context shared by the annotation helpers. `activeCallColors` maps an active
 // standard QSO's callsign to its stable colour; `workedCalls` is the set of
@@ -106,7 +193,6 @@ export function annotateDecode(record: DecodeRecord, ctx: AnnotateContext): Deco
 
 // AFs decoded in the most recent RX period of the given parity — "the last set
 // of decodes" for that slot. Empty until a period of that parity is heard.
-// Ported from the private helper in ui/tui.ts.
 export function latestSlotAfs(decodes: DecodeRecord[], parity: TxSlot): number[] {
   let latestStart = -1;
   for (const decode of decodes) {

--- a/core/view-model.ts
+++ b/core/view-model.ts
@@ -119,8 +119,8 @@ export interface CompletedQsoView {
 // already-logged callsigns (upper-case).
 export interface AnnotateContext {
   myCall: string;
-  activeCallColors: Map<string, string>;
-  workedCalls: Set<string>;
+  activeCallColors: ReadonlyMap<string, string>;
+  workedCalls: ReadonlySet<string>;
 }
 
 export function senderOf(message: string): string | null {

--- a/docs/plans/2026-07-14-001-refactor-operator-controller-plan.md
+++ b/docs/plans/2026-07-14-001-refactor-operator-controller-plan.md
@@ -1,0 +1,457 @@
+---
+title: QSO Automation Engine (OperatorController Extraction) - Plan
+type: refactor
+date: 2026-07-14
+topic: operator-controller
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-brainstorm
+execution: code
+---
+
+# QSO Automation Engine (OperatorController Extraction) - Plan
+
+## Goal Capsule
+
+- **Objective:** Extract the duplicated QSO orchestration out of the two clients into one
+  headless engine, `core/controller.ts` (`OperatorController`), that both the web and TUI
+  clients drive. This is workstream **W2** of `docs/rebuild-plan.md`; W1 (core/ foundation)
+  and W4 (EngineDriver seam) are done, so W2 is the remaining rebuild step.
+- **Authority:** The Product Contract governs behavior; the Planning Contract governs
+  implementation. Where they conflict, the Product Contract wins and the conflict is
+  surfaced, not resolved silently. This is an internal change — the daemon↔client wire
+  protocol and FT8 domain semantics (AF 200–3000 Hz, even/odd slots, FT8/FT4, snr/dt/af)
+  are the stable public seam and do not change.
+- **Product Contract preservation:** Product Contract unchanged. This run added the Planning
+  Contract, Implementation Units, Verification Contract, and Definition of Done, and resolved
+  Outstanding Questions OQ1–OQ3 into planning decisions (see Key Technical Decisions).
+- **Execution profile:** Web-first. Build the engine, port the web server's orchestration
+  onto it, land the headless full-QSO proof, then adopt the TUI last — proving the engine
+  before the second large client is touched.
+- **Stop conditions:** Stop and surface if porting the web orchestration cannot preserve the
+  existing web behavior without a Product Contract change, or if the headless full-QSO proof
+  cannot complete at scaled time without a wire-protocol change.
+- **Tail ownership:** Implementer runs the Verification Contract gates. This refactor is
+  fully reachable headless (simulated driver) — no real-hardware regression is required to
+  land it, though a live-rig smoke before the next user-facing ship remains the operator's.
+
+---
+
+## Product Contract
+
+### Summary
+
+Today the slot-aligned TX scheduler, survey, control-claim state, decode buffer, dial-freq
+tracking, and worked-call/logging side-effects live twice — once in `ui/tui.ts` (1571 lines,
+~96 automation touchpoints) and once in `ui/web/server.ts` (1169 lines, ~90). The pure QSO
+state machine (`core/qso.ts`) was already extracted in W1. W2 lifts the orchestration around
+it into a single `core/controller.ts` so both clients become thin: web reduces to transport
++ state mapping, the TUI to blessed render + input dispatch. The engine is proven end-to-end
+by a headless test that drives a full simulated QSO to completion at scaled time.
+
+### Problem Frame
+
+The rebuild review found QSO orchestration duplicated across the TUI and web clients and
+already drifting (finding #4). Every feature shipped since W1 — demo mode and the published
+slot clock on the current branch — has been paid for twice and has widened that drift: the
+TUI tracks TX intent as `manualOverridePending`, while the web client evolved a superset
+(`txEnabled` / `haltTx` / `controlClaimPending`). The two clients can now behave differently
+in the same situation, and the TUI's orchestration logic (~250 lines) is untestable because
+it is embedded in a blessed script. Extracting one engine both clients drive is what stops
+the drift and makes the automation logic testable.
+
+### Actors
+
+- **A1. Operator** — drives the engine through either client (web or TUI); must see the same
+  behavior regardless of which client they use.
+- **A2. Cloud agent** — verifies the engine headlessly in a container with no radio, using
+  the simulated driver, and must be able to prove a full QSO completes.
+- **A3. Both reference clients** — web and TUI, reduced to rendering + input, sharing one
+  engine and one view-model.
+
+### Requirements
+
+**R1 — One engine, both clients.** `core/controller.ts` owns the scheduler, survey,
+control-claim, decode buffer, dial-freq, and worked-call/logging orchestration, wrapping the
+existing `core/qso.ts`. After W2, no orchestration logic remains in `ui/web/server.ts` or
+`ui/tui.ts`; both drive the controller through injected dependencies.
+
+**R2 — Sequenced web-first, TUI follows.** Execution order within W2:
+
+1. Build `core/controller.ts`, porting the web server's orchestration (the reference of
+   truth) and refreshing the stale interface stub in `docs/rebuild-plan.md` §3.3 to carry
+   what demo mode and the slot clock added since it was written.
+2. Reduce `ui/web/server.ts` to transport + `ControllerState → StateMessage` mapping. Move
+   `ui/web/view-model.ts` → `core/view-model.ts` (W1's explicitly deferred item), UI-agnostic
+   so the TUI can render from it too.
+3. Land the done bar (R4) — the integration proof — against the extracted engine before the
+   second client is touched.
+4. Reduce `ui/tui.ts` to blessed render + input dispatch, reconciling its drifted behavior
+   onto the web's.
+
+**R3 — Behavior converges to web; the TUI changes.** This is not a pure behavior-preserving
+refactor. Unifying two clients into one engine forces one behavior, and the web client's
+superset control model wins. The TUI's drifted behaviors (notably `manualOverridePending`
+vs the web's `txEnabled` / `haltTx` / `controlClaimPending`) are reconciled onto the web's,
+which is an intended, observable change to the TUI.
+
+**R4 — Done means a headless full-QSO proof, plus unit coverage.** W2 is finished only when:
+- Unit tests cover the previously-untestable logic — scheduler timing with an injected clock,
+  survey, control-claim, and QSO event/logging.
+- An automated integration test drives `OperatorController` + the simulated driver through a
+  complete QSO (CQ → … → 73) to completion, **at scaled time**, headless, asserted in CI.
+- All existing gates stay green: `npm test`, `npm run build`, `npm run typecheck`,
+  `npm run smoke`, `npm run smoke:ui`.
+
+**R5 — Scheduler derives time from the published slot clock, scale factor included.** The
+controller's scheduler must schedule automated transmits against the daemon's published slot
+clock (epoch, duration, **and scale factor**), not a real-time timer. This is the load-bearing
+consequence of the scaled-time proof in R4: if the engine fires on real 15-second boundaries
+while the daemon runs slots at, e.g., 20×, no simulated QSO ever completes. The old stub's
+injected `now()` is insufficient on its own — the engine consumes the slot-clock triple.
+
+**R6 — Transport-abstract; daemon-promotion stays a relocation.** All dependencies
+(`DaemonClient`, clock, logger, QSO-log store) are injected, so the engine runs identically
+inside a client process today or inside the daemon later (the deferred option B). No code path
+assumes it lives client-side.
+
+**R7 — Demo-mode integrity survives the extraction.** Demo-mode labeling and the reserved
+demo identity carry through the engine unchanged: demo must remain unmistakably labeled in
+every client, and the reserved identity must never leak into persisted session config. See
+`CONCEPTS.md` (Demo mode, Reserved demo identity).
+
+### Non-Goals
+
+- **No daemon promotion.** The engine stays client-side; the daemon remains QSO-unaware
+  (rebuild plan option B, deferred). R6 only keeps that door open.
+- **No new QSO automation behavior.** W2 moves and consolidates existing orchestration; it
+  does not add station-selection strategy, auto-CQ tactics, multi-QSO handling, or survey
+  automation beyond what exists today.
+- **No wire-protocol or FT8-semantic changes.** The public daemon↔client contract is the
+  stable seam.
+- **Not W4 or W5.** The EngineDriver seam (W4) is done; security hardening (W5) stays
+  low-priority and out of scope here.
+
+### Success Criteria
+
+- No orchestration logic remains in `ui/tui.ts` or `ui/web/server.ts`; both drive one
+  `core/controller.ts`.
+- `ui/web/view-model.ts` has moved to `core/view-model.ts` and is UI-agnostic.
+- The headless full-QSO integration proof runs green in CI at scaled time; unit coverage of
+  scheduler/survey/control/logging is in place.
+- Web and TUI produce the same behavior for the same operator action (drift closed).
+- All existing gates stay green.
+
+### Outstanding Questions (resolved in planning)
+
+- **OQ1 — Refreshed `ControllerState` shape.** Resolved: `ControllerState` mirrors today's
+  web-server state, plus a `station.demo` flag; scheduler/survey/cycle fields continue to
+  derive from the injected `SlotClock`. See KTD2, U1.
+- **OQ2 — Integration-proof entry point.** Resolved: the proof drives the controller
+  **directly** against the simulated driver (UI-agnostic), landing before the TUI work. See
+  KTD5, U5.
+- **OQ3 — Control-state reconciliation detail.** Resolved: web's `controlHeld` /
+  `controlMine` / `controlClaimPending` + `txEnabled` / `haltTx` is canonical; the TUI's
+  `manualOverridePending` and `ensureControl` auto-claim fold into it. See KTD1, U6.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+**KTD1 — Port the web server's orchestration; do not merge two implementations.** The web
+server (`ui/web/server.ts`) is the more-evolved, reference-of-truth copy. The controller is
+built by lifting its orchestration verbatim, then having the TUI adopt it. The TUI's drifted
+control model (`manualOverridePending`) is discarded, not reconciled field-by-field —
+resolving finding #4 and R3/OQ3. Rationale: a field-by-field merge would re-introduce the
+drift the extraction exists to kill.
+
+**KTD2 — `ControllerState` mirrors the web server's current state, plus `station.demo`.** The
+§3.3 stub predates demo mode and the slot clock. The controller's state carries what the web
+server already tracks — station (`call`, `grid`, `dialFreqHz`, `catConnected`,
+`sessionActive`, `controlHeld`, `controlMine`, `demo`), tx card, survey, af, qsos (calling-cq
+/ active / completed), decodes, and the slot-clock-derived cycle. Scheduling and survey timing
+already flow through the injected `SlotClock` (`requireClock()` today), so R5 is preserved by
+the port rather than newly built.
+
+**KTD3 — Dependencies are injected; `qso-log.ts` is wrapped, not relocated.** The controller
+takes `DaemonClient`, a clock accessor, a logger sink, and a `QsoLogStore` (`append` /
+`readAll`) — all injected, satisfying R6 (transport-abstract, daemon-promotable). The concrete
+`QsoLogStore` wraps the existing `appendQsoLog` / `readQsoLog` in `ui/qso-log.ts`; physically
+moving that file into `core/` is deferred (see Scope Boundaries) because the seam does not
+require it.
+
+**KTD4 — `core/view-model.ts` renders from `ControllerState`; browser view types move with
+it.** The pure builders in `ui/web/view-model.ts` (`buildRosters`, `buildActiveQsoView`,
+`deriveTxCard`, `buildCycleView`, `cycleParity`, `annotateDecode`, `senderOf`, `gridFrom`,
+`latestSlotAfs`) already depend only on `core/qso.ts` and `core/slot-clock.ts` — their sole
+web coupling is importing the view types (`DecodeView`, `ActiveQsoView`, `CycleView`, etc.)
+from `ui/web/protocol.ts`. Those view types move into `core/view-model.ts`; `ui/web/protocol.ts`
+re-exports/aliases them for the browser wire (`StateMessage` stays web-owned). The TUI then
+renders from the same core builders, which also collapses the `senderOf` / `gridFrom`
+duplication (finding #7) as a side effect rather than as separate cleanup.
+
+**KTD5 — The integration proof drives the controller directly at scaled time.** The R4 proof
+instantiates `OperatorController` with the simulated driver's `DaemonClient` and a scaled
+`SlotClock`, and asserts a full QSO reaches `complete` with a log entry — no web or TUI
+process in the loop. Rationale (OQ2): a UI-agnostic proof lands before the TUI adoption (U6)
+and guards the engine itself, which is the asset both clients share.
+
+### High-Level Technical Design
+
+Component shape after extraction — one engine, two thin clients, all deps injected:
+
+```mermaid
+graph TD
+  DC[core/daemon-client.ts<br/>DaemonClient] --> OC
+  SC[core/slot-clock.ts<br/>SlotClock] --> OC
+  LS[QsoLogStore<br/>wraps ui/qso-log.ts] --> OC
+  QA[core/qso.ts<br/>QsoAutomation] --> OC
+  OC[core/controller.ts<br/>OperatorController<br/>scheduler · survey · control · decodes] --> VM
+  VM[core/view-model.ts<br/>pure builders + view types]
+  OC --> WS[ui/web/server.ts<br/>transport + ControllerState→StateMessage]
+  OC --> TUI[ui/tui.ts<br/>blessed render + input]
+  VM --> WS
+  VM --> TUI
+```
+
+The R4 headless proof, at scaled time, exercises the scheduler→driver→confirm loop end to end:
+
+```mermaid
+sequenceDiagram
+  participant Sim as Simulated driver
+  participant OC as OperatorController
+  participant Clk as SlotClock (scaled)
+  Sim->>OC: decode (CQ / reply / report)
+  OC->>OC: QsoAutomation.handleDecode → advance step
+  OC->>Clk: secondsUntilNextSlot (scale-corrected)
+  OC->>Sim: transmit(intent) pre-armed before slot
+  Sim->>OC: tx confirm
+  OC->>OC: confirmTransmission → count attempt / advance
+  Note over OC: repeat until step = 73
+  OC->>OC: complete QSO → QsoLogStore.append
+```
+
+### Implementation Units
+
+#### U1. Scaffold `core/controller.ts` — interface, `ControllerState`, injected deps
+
+- **Goal:** Establish the engine skeleton: the `OperatorController` interface, the
+  `ControllerState` shape, the injected dependency set, and the `onChange` emitter — no
+  orchestration behavior yet.
+- **Requirements:** R1, R6; resolves OQ1.
+- **Dependencies:** none.
+- **Files:** `core/controller.ts` (new); `test/controller.test.ts` (new).
+- **Approach:** Define `OperatorControllerDeps` (`client: DaemonClient`, `log: QsoLogStore`,
+  `clock` accessor, `onLog` sink, `token?`, `now?`) and `ControllerState` per KTD2 (station
+  incl. `demo`, tx, survey, af, qsos, decodes, cycle). Implement construction, `state`
+  getter, `onChange(listener) → unsubscribe`, and `start()` / `dispose()` lifecycle stubs.
+  Operator-action method signatures (`setIdentity`, `setAf`, `setSlot`, `callCq`, `stopCq`,
+  `replyToCall`, `qsoAction`, `survey`, `setTxEnabled`, `haltTx`, `startSession`,
+  `stopSession`, `releaseControl`) are declared and no-op/throw until U2.
+- **Patterns to follow:** the §3.3 stub in `docs/rebuild-plan.md`, refreshed per KTD2; the
+  `DaemonClient` event/emitter style in `core/daemon-client.ts`.
+- **Test scenarios:**
+  - `onChange` listener fires on state mutation and stops after its unsubscribe is called.
+  - `dispose()` clears timers and unsubscribes from the injected client (no emissions after).
+  - Initial `ControllerState` has `station.demo === false` and empty qso/decode collections.
+- **Verification:** `core/controller.ts` type-checks against the injected deps; the skeleton
+  tests pass; no client imports it yet.
+
+#### U2. Port the web server's orchestration into the controller
+
+- **Goal:** Move the automation engine — scheduler, survey, control-claim, tx-enable, decode
+  buffer, dial-freq, QSO event handling and logging, and the daemon-client wiring — out of
+  `ui/web/server.ts` and into `core/controller.ts`, preserving web behavior exactly.
+- **Requirements:** R1, R3, R5, R7; KTD1, KTD2, KTD3.
+- **Dependencies:** U1.
+- **Files:** `core/controller.ts`; `test/controller.test.ts`.
+- **Approach:** Port `automation` (QsoAutomation), `scheduleAutomation` / `sendAutomatedTx` /
+  `clearAutomationTimer` / `clearAutomationState`, `startSurvey` / `finishSurvey` and survey
+  state, the control model (`controlHeld` / `controlMine` / `controlClaimPending`, the
+  claim-on-demand path), `txEnabled` / `haltTx` / `setTxEnabled`, `updateTxState`,
+  `currentTxSlot` / `currentAfOrNull`, `handleQsoEvents` / `logCompletedQso`, and the
+  `client.on(...)` handlers for `status` / `decode` / `tx` / `tx_update` / `log` /
+  `daemonError` / `config` / `audio_devices`. Scheduling stays on the injected `SlotClock`
+  (R5) exactly as the web server does today via `requireClock()`. Demo labeling flows into
+  `station.demo` from the engine-kind/status signal (R7). Every mutation routes through the
+  `onChange` emitter instead of `broadcastState()`.
+- **Execution note:** Port incrementally with the unit tests below landing alongside each
+  slice (scheduler, then survey, then control, then logging) — this is the logic that was
+  untestable in-place, so tests are the proof the port is faithful.
+- **Patterns to follow:** `ui/web/server.ts` lines ~362–525 (scheduler + survey), ~396–410
+  (`updateTxState`), ~540–563 (control claim), ~733–747 (`haltTx` / `setTxEnabled`),
+  ~315–360 (QSO events + logging).
+- **Test scenarios:**
+  - Scheduler (injected clock): with an active QSO and valid AF, an automated `transmit` is
+    pre-armed ~2s before the eligible slot; inside the pre-arm window it sends immediately.
+  - Scheduler gates: no transmit while `!sessionActive`, `surveyActive`, `!txEnabled`, or
+    `latestTxState === "active"`.
+  - Attempts: a step's attempt count increments only on a daemon `tx` confirm, not on send;
+    the step times out after 5 confirmed attempts and the QSO stays in the active list.
+  - Survey: `startSurvey` holds TX for one receive cycle of the TX parity and re-schedules on
+    `finishSurvey`; survey is refused with a logged warning when no slot clock is published.
+  - Control: a state-changing action claims control when not held, guarded by
+    `controlClaimPending`; releasing control resets the flags.
+  - QSO logging: a completed standard QSO with a real `theirCall` appends one `QsoLogEntry`
+    via the injected `QsoLogStore`; a stopped CQ row logs nothing.
+  - Demo: `station.demo` is true under the simulated engine and false otherwise.
+- **Verification:** the ported unit tests pass; behavior matches the web server's current
+  observable behavior for each ported path.
+
+#### U3. Relocate the view-model to `core/`, decoupled from the browser protocol
+
+- **Goal:** Move `ui/web/view-model.ts` → `core/view-model.ts` so it renders from
+  `ControllerState` / core types and both clients can use it (W1's deferred item).
+- **Requirements:** R1; KTD4. Advances Success Criterion "view-model has moved to core".
+- **Dependencies:** U1.
+- **Files:** `core/view-model.ts` (new, moved); `ui/web/view-model.ts` (removed);
+  `ui/web/protocol.ts` (re-export/alias view types); `test/web-view-model.test.ts` →
+  `test/view-model.test.ts` (moved); `core/protocol.ts` or `core/view-model.ts` (home for the
+  moved view types).
+- **Approach:** Move the pure builders and the view types they return (`DecodeView`,
+  `RosterEntryView`, `ActiveQsoView`, `CompletedQsoView`, `CycleView`, `NowView`,
+  `StationView` fields) into `core/view-model.ts`. Keep `StateMessage` / `CommandMessage`
+  web-owned in `ui/web/protocol.ts`, re-exporting the moved view types so the browser wire is
+  unchanged. Builders take `ControllerState` (or its sub-shapes) as input rather than
+  web-server locals.
+- **Patterns to follow:** existing `ui/web/view-model.ts` builder signatures; keep pure — no
+  I/O, no mutation of `QsoRecord`.
+- **Test scenarios:**
+  - Every existing `web-view-model` test passes unchanged after the move (behavior parity).
+  - `annotateDecode` / `buildRosters` / `buildActiveQsoView` produce identical output from a
+    `ControllerState` fixture as they did from the old web-server inputs.
+  - `core/view-model.ts` imports nothing from `ui/`.
+- **Verification:** `npm run typecheck` passes for both tsconfigs; the browser bundle sees no
+  contract change; view-model tests green.
+
+#### U4. Reduce `ui/web/server.ts` to transport + state mapping
+
+- **Goal:** Shrink the web server to: instantiate the controller, subscribe `onChange`, map
+  `ControllerState → StateMessage` via `core/view-model.ts`, and dispatch browser
+  `CommandMessage`s to controller methods.
+- **Requirements:** R1; Success Criterion "no orchestration remains in server.ts".
+- **Dependencies:** U2, U3.
+- **Files:** `ui/web/server.ts`; `test/web-server.test.ts`.
+- **Approach:** Delete the orchestration now living in the controller. The server owns only
+  the http/static server, the browser WS bridge, controller construction with concrete deps
+  (real `DaemonClient`, `QsoLogStore` over `ui/qso-log.ts`), and the `ControllerState →
+  StateMessage` projection. The headless self-test harness (`waitUntil` control-claim path)
+  drives controller methods rather than internal locals.
+- **Test scenarios:**
+  - A browser `CommandMessage` (`callCq`, `setAf`, `haltTx`, `qsoAction`, `releaseControl`)
+    invokes the matching controller method exactly once.
+  - A controller `onChange` emission produces a `StateMessage` broadcast to connected browser
+    sockets.
+  - The existing web integration tests (session start, demo start, control claim) pass with
+    the controller underneath.
+- **Verification:** `test/web-server.test.ts` green; no scheduler/survey/automation symbols
+  remain in `ui/web/server.ts` (grep check in Verification Contract).
+
+#### U5. Headless full-QSO integration proof + controller done-bar coverage
+
+- **Goal:** Prove the engine end-to-end: the controller, driven by the simulated driver at
+  scaled time, completes a full QSO and logs it — the R4 done bar.
+- **Requirements:** R4, R5; KTD5, resolves OQ2.
+- **Dependencies:** U2 (drives the controller directly; sequenced after U4 per R2).
+- **Files:** `test/controller-integration.test.ts` (new).
+- **Approach:** Instantiate `OperatorController` with a `DaemonClient` bound to the simulated
+  driver and a scaled `SlotClock`, start a simulated session, call `callCq` (or
+  `replyToCall`), and advance virtual time. Assert the QSO walks `cq → … → 73`, reaches
+  `complete`, and produces exactly one `QsoLogEntry` through an in-memory `QsoLogStore`.
+  Assert it completes in bounded wall time because the scheduler honors the scale factor (R5)
+  — a real-time scheduler would hang the test, which is the regression this proof guards.
+- **Execution note:** Start from a failing integration test asserting completion, then confirm
+  the ported scheduler drives it green at scale — this is the contract the whole extraction
+  serves.
+- **Patterns to follow:** `test/simulated-driver.test.ts` and `test/demo-mode.test.ts` for
+  wiring the simulated driver and scaled clock; `test/slot-clock.test.ts` for scaled-time
+  assertions.
+- **Test scenarios:**
+  - Covers R4. Reply-to-CQ: a simulated station's CQ → controller completes a standard QSO to
+    `73` and logs one entry, headless, at ≥10× scale, within a bounded wall-clock budget.
+  - Calling CQ: controller calls CQ, a simulated station answers, the CQ row stops and a
+    standard QSO completes and logs.
+  - Scale integrity: at 20× scale the QSO completes; a real-time (`scale = 1`) scheduler over
+    the same script would exceed the test's wall budget (guards R5).
+  - No log entry is written for an abandoned or stopped-CQ QSO.
+- **Verification:** `test/controller-integration.test.ts` green in CI; the run demonstrably
+  completes faster than real-time slot cadence would allow.
+
+#### U6. Reduce `ui/tui.ts` to render + input; adopt the controller
+
+- **Goal:** Shrink the TUI to blessed rendering of `ControllerState` + input dispatch to
+  controller methods, folding its drifted behavior onto the web's canonical model.
+- **Requirements:** R1, R3; KTD1, KTD4, resolves OQ3.
+- **Dependencies:** U3, U4, U5.
+- **Files:** `ui/tui.ts`; `ui/tui-state.ts` (if orchestration-coupled); `test/tui-state.test.ts`.
+- **Approach:** Instantiate the controller, render from `core/view-model.ts`, and route key/
+  mouse handlers to controller methods. Remove `manualOverridePending`, `pendingAutomationTx`,
+  the local scheduler/survey state, `ensureControl`, and the duplicated `senderOf` / `gridFrom`
+  (now from the shared view-model). TX-enable / halt / control-claim behavior comes from the
+  controller — the TUI adopts web's model (R3). Preserve TUI-only affordances (band log,
+  status-bar clock segment) as render concerns.
+- **Test scenarios:**
+  - Covers R3. A TUI TX action drives the controller's `txEnabled` / `haltTx` path, not the
+    removed `manualOverridePending` (behavior now matches web).
+  - `test/tui-state.test.ts` state persistence still round-trips after the reduction.
+  - The TUI renders a full `ControllerState` fixture (active QSOs, survey, demo label) without
+    reaching into engine internals.
+  - Demo label is unmistakably shown in the TUI status bar (R7).
+- **Verification:** no scheduler/survey/automation symbols remain in `ui/tui.ts` (grep check);
+  `npm run smoke` (TUI non-crash) passes; behavior parity with web spot-checked.
+
+### Verification Contract
+
+- **Gates (all must stay green):** `npm test`, `npm run build`, `npm run typecheck`,
+  `npm run smoke`, `npm run smoke:ui`.
+- **New coverage:** controller unit tests (scheduler with injected clock, survey,
+  control-claim, QSO event/logging — U2) and the headless full-QSO integration proof at scaled
+  time (U5).
+- **Structural check:** after U4 and U6, a grep for orchestration symbols
+  (`scheduleAutomation`, `startSurvey`, `QsoAutomation`, `manualOverridePending`,
+  `automationTimer`) returns nothing in `ui/web/server.ts` or `ui/tui.ts`.
+- **Isolation check:** `core/view-model.ts` and `core/controller.ts` import nothing from
+  `ui/`.
+- **Parity check:** the same operator action produces the same behavior in web and TUI (the
+  drift the extraction closes).
+
+### Definition of Done
+
+- R1–R7 satisfied: one `core/controller.ts` engine, both clients thin and driving it,
+  view-model in `core/`, demo integrity preserved, deps injected, scheduler on the slot clock.
+- The headless full-QSO proof is green in CI at scaled time; controller unit coverage is in
+  place.
+- All Verification Contract gates and checks pass.
+- No orchestration logic remains in `ui/web/server.ts` or `ui/tui.ts`; web and TUI behavior
+  match.
+
+---
+
+## Scope Boundaries
+
+### Deferred to Follow-Up Work
+
+- Physically relocating `ui/qso-log.ts` into `core/` — the controller injects a `QsoLogStore`
+  over its existing helpers (KTD3), so the move is not required by the seam.
+- Any `senderOf` / `gridFrom` dedup beyond what the view-model move (U3/KTD4) collapses
+  naturally.
+
+### Out of Scope (product non-goals)
+
+- Promoting the engine into the daemon (rebuild plan option B); new QSO automation behavior;
+  wire-protocol or FT8-semantic changes; W4 and W5 work. See Product Contract Non-Goals.
+
+---
+
+## References
+
+- `docs/rebuild-plan.md` — W2 definition, §3.3 `OperatorController` interface stub, findings
+  #2/#3/#4/#7/#8/#10 that W2 closes.
+- `core/qso.ts` — the pure QSO state machine the engine wraps (already extracted in W1).
+- `core/slot-clock.ts`, `docs/plans/2026-07-13-001-feat-simulated-engine-demo-mode-plan.md` —
+  the slot-clock contract and simulated driver the R4 proof and R5 constraint depend on.
+- `ui/web/server.ts`, `ui/web/view-model.ts` — the reference-of-truth orchestration and pure
+  builders being ported and relocated.
+- `CONCEPTS.md` — Session, Engine driver, Demo mode, Slot clock, Reserved demo identity.

--- a/test/controller-integration.test.ts
+++ b/test/controller-integration.test.ts
@@ -1,0 +1,123 @@
+import { EventEmitter } from "node:events";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { realtimeClockSpec } from "../core/slot-clock.js";
+import { DaemonClient } from "../core/daemon-client.js";
+import { createOperatorController, type OperatorController, type QsoLogStore } from "../core/controller.js";
+import type { AudioDevice } from "../src/daemon/audio-devices.js";
+import { Engine } from "../src/daemon/engine.js";
+import type { EngineDriver, EngineDriverEvents } from "../src/daemon/engine-driver.js";
+import type { EngineKind, SlotClockSpec, TxIntent } from "../src/daemon/protocol.js";
+import { SimulatedDriver } from "../src/daemon/simulated-driver.js";
+import { isNonAssignableCallsign } from "../src/daemon/sim-station.js";
+import { createDaemonWebSocketServer, type DaemonWebSocketServer } from "../src/daemon/websocket.js";
+import type { QsoLogEntry } from "../core/qso.js";
+
+// Stands in for the real radio; a demo session must never select it.
+class RealDriverStub extends EventEmitter<EngineDriverEvents> implements EngineDriver {
+  readonly kind: EngineKind = "ft8cat";
+  started = 0;
+  clock(): SlotClockSpec {
+    return realtimeClockSpec();
+  }
+  async start(): Promise<void> {
+    this.started += 1;
+  }
+  async stop(): Promise<void> {}
+  async transmit(_intent: TxIntent): Promise<void> {}
+  async cancelTransmit(): Promise<void> {}
+  async listAudioDevices(): Promise<AudioDevice[]> {
+    return [];
+  }
+}
+
+class MemoryQsoLog implements QsoLogStore {
+  readonly entries: QsoLogEntry[] = [];
+  async append(entry: QsoLogEntry): Promise<void> {
+    this.entries.push(entry);
+  }
+  async readAll(): Promise<QsoLogEntry[]> {
+    return this.entries;
+  }
+}
+
+const servers: DaemonWebSocketServer[] = [];
+const controllers: OperatorController[] = [];
+
+afterEach(async () => {
+  for (const controller of controllers.splice(0)) {
+    controller.dispose();
+  }
+  for (const server of servers.splice(0)) {
+    await server.close();
+  }
+});
+
+async function startSimDaemon(scale: number): Promise<{ url: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "digi-dx-ctl-"));
+  const configPath = join(dir, "config.json"); // absent on purpose
+  const engine = new Engine({
+    driver: new RealDriverStub(),
+    simulatedDriver: new SimulatedDriver({ scale, seed: 7 })
+  });
+  const port = 18990 + Math.floor(Math.random() * 900);
+  const server = createDaemonWebSocketServer({ engine, port, configPath });
+  servers.push(server);
+  return { url: `ws://127.0.0.1:${port}` };
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs: number, label: string): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error(`timed out waiting for ${label}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+describe("OperatorController end-to-end against the simulated driver", () => {
+  it("drives a full simulated QSO to completion and logs it, at scaled time", async () => {
+    const scale = 100;
+    const { url } = await startSimDaemon(scale);
+    const log = new MemoryQsoLog();
+    const client = new DaemonClient({ url, reconnectMs: 2000 });
+    const controller = createOperatorController({ client, log });
+    controllers.push(controller);
+
+    controller.start();
+    await waitFor(() => client.connected, 15_000, "daemon connection");
+
+    // Start the demo session: the daemon selects the simulated engine, synthesizes
+    // a demo identity, and publishes its scaled clock. The controller adopts all
+    // three from status; simulated stations then call the demo callsign and the
+    // automation works the QSO from this side with no further operator action.
+    const startedAt = Date.now();
+    controller.startDemo();
+    await waitFor(
+      () => Boolean(controller.state.station.sessionActive && controller.state.station.demo && controller.state.clock),
+      15_000,
+      "demo session live"
+    );
+    expect(controller.state.clock?.spec.scale).toBe(scale);
+
+    // The engine completes and logs a QSO end to end, headless.
+    await waitFor(() => log.entries.length > 0, 25_000, "a completed QSO in the log");
+    const elapsedWallMs = Date.now() - startedAt;
+
+    const entry = log.entries[0]!;
+    expect(entry.theirCall).toBeTruthy();
+    // Demo contacts can never be a real licensee.
+    expect(isNonAssignableCallsign(entry.theirCall)).toBe(true);
+    expect(entry.sentReport).toBeTruthy();
+    expect(entry.receivedReport).toBeTruthy();
+
+    // Scale integrity (R5): a full QSO spans ~6 FT8 slots (~90 virtual seconds).
+    // At scale 100 that is ~1s of wall time; a scheduler that ignored the scale
+    // factor and armed on real 15-second boundaries could not finish inside this
+    // budget, so completing under it proves the scheduler honored the clock.
+    expect(elapsedWallMs).toBeLessThan(30_000);
+  }, 40_000);
+});

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DaemonClient } from "../core/daemon-client.js";
+import {
+  createOperatorController,
+  type ControllerState,
+  type OperatorController,
+  type QsoLogStore
+} from "../core/controller.js";
+import { realtimeClockSpec, type SlotClockSpec } from "../core/slot-clock.js";
+import type { DaemonCommand, DaemonStatus, EngineKind } from "../core/protocol.js";
+import type { QsoLogEntry } from "../core/qso.js";
+
+// A DaemonClient that never opens a socket: connect/close are no-ops, send just
+// records the command, and tests drive the controller by emitting daemon events
+// on it directly (it is a real EventEmitter, so the controller's subscriptions
+// fire exactly as they would against a live daemon).
+class FakeDaemonClient extends DaemonClient {
+  readonly sent: DaemonCommand[] = [];
+  constructor() {
+    super({ url: "ws://test" });
+  }
+  override connect(): void {}
+  override close(): void {}
+  override send(command: DaemonCommand): boolean {
+    this.sent.push(command);
+    return true;
+  }
+}
+
+class MemoryQsoLog implements QsoLogStore {
+  readonly entries: Array<{ entry: QsoLogEntry; engine: EngineKind }> = [];
+  async append(entry: QsoLogEntry, engine: EngineKind): Promise<void> {
+    this.entries.push({ entry, engine });
+  }
+  async readAll(): Promise<QsoLogEntry[]> {
+    return this.entries.map((e) => e.entry);
+  }
+}
+
+function statusMessage(overrides?: {
+  active?: boolean;
+  byThisClient?: boolean;
+  held?: boolean;
+  engine?: EngineKind;
+  clock?: SlotClockSpec;
+  txState?: "idle" | "pending" | "active";
+  callsign?: string | null;
+  grid?: string | null;
+}): DaemonStatus {
+  return {
+    type: "status",
+    engine: overrides?.engine ?? "ft8cat",
+    clock: overrides?.clock ?? realtimeClockSpec(),
+    session: {
+      active: overrides?.active ?? true,
+      mode: "FT8",
+      device: null,
+      catConnected: true,
+      freq: null,
+      ptt: false,
+      callsign: overrides?.callsign ?? null,
+      grid: overrides?.grid ?? null
+    },
+    tx: { state: overrides?.txState ?? "idle", af: null, slot: null, message: null },
+    control: { held: overrides?.held ?? true, byThisClient: overrides?.byThisClient ?? true }
+  };
+}
+
+function build(): {
+  controller: OperatorController;
+  client: FakeDaemonClient;
+  log: MemoryQsoLog;
+} {
+  const client = new FakeDaemonClient();
+  const log = new MemoryQsoLog();
+  const controller = createOperatorController({ client, log });
+  controller.start();
+  return { controller, client, log };
+}
+
+const sentTypes = (client: FakeDaemonClient): string[] => client.sent.map((c) => c.type);
+
+describe("OperatorController", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("emits state to listeners and stops after unsubscribe", () => {
+    const { controller } = build();
+    const seen: ControllerState[] = [];
+    const off = controller.onChange((s) => seen.push(s));
+    controller.setIdentity("N1MPM", "FN42");
+    expect(seen.length).toBeGreaterThan(0);
+    off();
+    const before = seen.length;
+    controller.setIdentity("N1MPM", "FN43");
+    expect(seen.length).toBe(before);
+  });
+
+  it("starts idle: no demo, empty collections", () => {
+    const { controller } = build();
+    const s = controller.state;
+    expect(s.station.demo).toBe(false);
+    expect(s.qsos.active).toEqual([]);
+    expect(s.qsos.completed).toEqual([]);
+    expect(s.decodes).toEqual([]);
+    expect(s.tx.enabled).toBe(true);
+  });
+
+  it("labels demo mode when the simulated engine is running", () => {
+    const { controller, client } = build();
+    client.emit("status", statusMessage({ engine: "simulated" }));
+    expect(controller.state.station.demo).toBe(true);
+  });
+
+  it("dispose clears timers and unsubscribes from the client", () => {
+    const { controller, client } = build();
+    client.emit("status", statusMessage());
+    controller.dispose();
+    const seen: ControllerState[] = [];
+    controller.onChange((s) => seen.push(s));
+    // After dispose the controller no longer reacts to daemon events.
+    client.emit("status", statusMessage({ engine: "simulated" }));
+    expect(seen.length).toBe(0);
+    expect(controller.state.station.demo).toBe(false);
+  });
+
+  it("a state-changing action claims control when it is not held by us", () => {
+    const { controller, client } = build();
+    // Config incomplete, so start_session won't fire — but control is still claimed.
+    client.emit("status", statusMessage({ byThisClient: false, held: false }));
+    controller.startSession();
+    expect(sentTypes(client)).toContain("claim_control");
+    expect(sentTypes(client)).not.toContain("start_session");
+  });
+
+  it("schedules and sends an automated CQ at the slot with control and a valid AF", () => {
+    const { controller, client } = build();
+    controller.setIdentity("N1MPM", "FN42");
+    client.emit("status", statusMessage({ byThisClient: true }));
+    controller.setAf(1200);
+    controller.callCq("even");
+    // Timer armed ~2s before the next even slot (opens at t=30s at scale 1);
+    // advance past it to fire the transmit.
+    vi.advanceTimersByTime(31_000);
+    const transmit = client.sent.find((c) => c.type === "transmit");
+    expect(transmit).toBeDefined();
+    expect((transmit as { message: string }).message).toMatch(/^CQ N1MPM FN42/);
+  });
+
+  it("does not transmit while TX is disabled", () => {
+    const { controller, client } = build();
+    controller.setIdentity("N1MPM", "FN42");
+    client.emit("status", statusMessage({ byThisClient: true }));
+    controller.setAf(1200);
+    controller.setTxEnabled(false);
+    controller.callCq("even");
+    vi.advanceTimersByTime(20_000);
+    expect(sentTypes(client)).not.toContain("transmit");
+  });
+
+  it("survey holds TX and refuses without a slot clock", () => {
+    const { controller, client } = build();
+    // No status yet => no clock => survey refuses.
+    controller.survey();
+    expect(controller.state.survey.active).toBe(false);
+    // With a clock, survey engages.
+    controller.setIdentity("N1MPM", "FN42");
+    client.emit("status", statusMessage({ byThisClient: true }));
+    controller.survey();
+    expect(controller.state.survey.active).toBe(true);
+  });
+
+  it("logs exactly one entry when a standard QSO completes", async () => {
+    const { controller, client, log } = build();
+    controller.setIdentity("N1MPM", "FN42");
+    client.emit("status", statusMessage({ byThisClient: true }));
+    controller.replyToCall("JA2KVB");
+    const id = controller.state.qsos.active[0]?.id;
+    expect(id).toBeDefined();
+    controller.qsoAction(id!, "complete");
+    await vi.runAllTimersAsync();
+    expect(log.entries).toHaveLength(1);
+    expect(log.entries[0]!.entry.theirCall).toBe("JA2KVB");
+  });
+
+  it("persists the dial frequency through the injected state store", async () => {
+    const client = new FakeDaemonClient();
+    const log = new MemoryQsoLog();
+    const writes: Array<{ dialFreqHz?: number | null }> = [];
+    const controller = createOperatorController({
+      client,
+      log,
+      state: {
+        read: async () => ({}),
+        write: async (patch) => {
+          writes.push(patch);
+        }
+      }
+    });
+    controller.start();
+    controller.setDialFreq(14.074);
+    await vi.runAllTimersAsync();
+    expect(controller.state.station.dialFreqHz).toBe(14_074_000);
+    expect(writes.at(-1)).toEqual({ dialFreqHz: 14_074_000 });
+  });
+});

--- a/test/view-model.test.ts
+++ b/test/view-model.test.ts
@@ -10,7 +10,7 @@ import {
   deriveTxCard,
   latestSlotAfs,
   senderOf
-} from "../ui/web/view-model.js";
+} from "../core/view-model.js";
 
 describe("web view-model helpers", () => {
   it("classifies replies, active QSOs, worked calls, and normal decodes", () => {

--- a/ui/tui.ts
+++ b/ui/tui.ts
@@ -977,11 +977,9 @@ client.on("config", (msg) => {
   }
 });
 
-client.on("close", () => {
-  // Band Activity is left in place; the engine resets its own state.
-  bandRows.length = 0;
-  lastBandPeriod = null;
-});
+// Band Activity persists across reconnects (its row->decode mapping must stay in
+// sync with the blessed list); the engine resets its own state on close and the
+// status bar follows via onChange.
 
 // The engine drives everything else.
 controller.onChange((next) => {

--- a/ui/tui.ts
+++ b/ui/tui.ts
@@ -2,113 +2,87 @@ import blessed from "blessed";
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { DaemonClient } from "../core/daemon-client.js";
-import type { DaemonCommand } from "../core/protocol.js";
 import { appendQsoLog, qsoLogPathFor, readQsoLog } from "./qso-log.js";
 import { readTuiState, writeTuiState } from "./tui-state.js";
 import { bandForMHz, buildAdif } from "./adif.js";
 import {
   findOccupiedAf,
   messageForQso,
-  oppositeSlot,
-  parseFt8Message,
-  QsoAutomation,
   renderOccupancyBar,
   slotFromTimestamp,
-  suggestClearAf,
-  type AutomationTx,
   type DecodeRecord,
-  type QsoAutomationEvent,
   type QsoRecord,
   type TxSlot
 } from "../core/qso.js";
-import { SlotClock } from "../core/slot-clock.js";
 import type { EngineKind } from "../core/protocol.js";
+import type { SlotClock } from "../core/slot-clock.js";
+import { gridFrom, latestSlotAfs, senderOf } from "../core/view-model.js";
+import {
+  createOperatorController,
+  type ControllerState,
+  type QsoLogStore,
+  type StateStore
+} from "../core/controller.js";
 
 const url = process.env.DIGI_DX_URL ?? "ws://127.0.0.1:8788";
 const token = process.env.DIGI_DX_AUTH_TOKEN;
 
-const decodes: DecodeRecord[] = [];
+// The engine owns all QSO orchestration; the TUI only renders its ControllerState
+// and routes input to its methods. The one thing the TUI reads straight off the
+// wire is the raw decode/tx stream, because Band Activity is an append-driven
+// event log, not a snapshot — so it subscribes to the shared daemon client for
+// those rows while the controller (sharing that client) does the automation.
+const client = new DaemonClient({ url, token, logger: (message) => appendLog(message) });
 
-// Band Activity is a chronological list of rows: decodes, per-cycle separators,
-// and our own TX lines. bandRows mirrors the list items 1:1 so a selected row
-// maps back to its decode (separators/TX rows are not selectable for reply).
-type BandRow = { kind: "decode"; decode: DecodeRecord } | { kind: "sep" } | { kind: "tx" };
-const bandRows: BandRow[] = [];
-let lastBandPeriod: number | null = null;
+const qsoLog: QsoLogStore = {
+  append: (entry, engine: EngineKind) => appendQsoLog(entry, qsoLogPathFor(engine)),
+  readAll: () => readQsoLog()
+};
+const stateStore: StateStore = {
+  read: () => readTuiState(),
+  write: (patch) => writeTuiState({ dialFreqHz: patch.dialFreqHz ?? null })
+};
+const controller = createOperatorController({
+  client,
+  log: qsoLog,
+  state: stateStore,
+  token,
+  onLog: (_level, text) => appendLog(text),
+  bandForMHz
+});
 
-let myCall = "";
-let myGrid = "";
+// The latest engine snapshot, refreshed on every controller change. All render
+// functions read from it rather than from any local automation state.
+let state: ControllerState = controller.state;
 
-// --- automation state -----------------------------------------------------
-
-// The daemon is the authority on slot timing. We adopt the clock it publishes and
-// derive every slot decision from it. There is deliberately no wall-clock
-// fallback: before the first status, and after a reconnect, we have no clock, and
-// a silent `Date.now()` fallback is exactly the bug a scaled clock would hide.
-let clock: SlotClock | null = null;
-
-function requireClock(): SlotClock {
-  if (!clock) {
-    throw new Error("slot clock unavailable: no status received from the daemon yet");
-  }
-  return clock;
-}
-
-// Late-bound over the clock we adopt, and it throws rather than reaching for
-// `Date.now()` -- this is the one place that decides every logged QSO's
-// timestamp. Safe because the daemon sends a status on connect, before any
-// decode can arrive.
-const automation = new QsoAutomation(() => new Date(requireClock().now()));
-let selectedQsoId: string | null = null;
-let pendingAutomationTx: AutomationTx | null = null;
-let automationTimer: NodeJS.Timeout | null = null;
-let manualOverridePending = false;
-let latestTxState: "idle" | "pending" | "active" = "idle";
-let statusBase = "connecting...";
-const loggedQsoIds = new Set<string>();
-
-// Control/session state, tracked structurally from status updates so the
-// Start/Stop toggle and the auto-claim logic run off real state, not strings.
-let controlHeld = false;
-let controlMine = false;
-let sessionActive = false;
-let configComplete = false;
-
-// Operator-entered dial frequency (Hz). CAT control reports the wrong band on
-// this setup, so this manual value is what gets logged and exported. Null until
-// the operator sets it via the "freq…" command.
-let dialFreqHz: number | null = null;
-
-// Callsigns already in the QSO log — their decodes are greyed in Band Activity
-// so we don't call a station we have already worked. Seeded from the log file
-// at startup and extended as QSOs complete this session.
-const workedCalls = new Set<string>();
-
-// Slot survey: hold TX for one full receive cycle of our TX parity so the
-// (otherwise deaf) TX slot can be observed, then suggest a clear frequency.
-const SURVEY_LO_HZ = 300;
-const SURVEY_HI_HZ = 2700;
-const SURVEY_DECODE_LAG_SECONDS = 5;
-// Virtual seconds of lead before the slot opens, so it scales with the clock.
-const AUTOMATION_LEAD_SECONDS = 2;
-let engineKind: EngineKind = "ft8cat";
-let surveyActive = false;
-let surveySlot: TxSlot | null = null;
-let surveyStartSec = 0;
-let surveyEndSec = 0;
-let surveyTimer: NodeJS.Timeout | null = null;
-const PLOT_WIDTH = 24;
-
-// Last device id seen in a status update, used to pre-fill the save dialog.
-let lastDeviceId: number | null = null;
-
-const client = new DaemonClient({ url, token, logger: appendLog });
-
-function send(command: DaemonCommand): void {
+function send(command: Parameters<DaemonClient["send"]>[0]): void {
   if (!client.send(command)) {
     appendLog("not connected yet");
   }
 }
+
+function clock(): SlotClock | null {
+  return state.clock;
+}
+
+// --- local render state ----------------------------------------------------
+
+// Band Activity's own decode buffer, fed by the raw decode stream. Kept separate
+// from the engine's buffer so the append-driven list and occupancy plots stay
+// exactly as they were.
+const decodes: DecodeRecord[] = [];
+
+type BandRow = { kind: "decode"; decode: DecodeRecord } | { kind: "sep" } | { kind: "tx" };
+const bandRows: BandRow[] = [];
+let lastBandPeriod: number | null = null;
+
+let statusBase = "connecting...";
+let selectedQsoId: string | null = null;
+let lastDeviceId: number | null = null;
+
+const PLOT_WIDTH = 24;
+const SURVEY_LO_HZ = 300;
+const SURVEY_HI_HZ = 2700;
 
 // --- screen and widgets --------------------------------------------------
 
@@ -129,8 +103,6 @@ const statusBar = blessed.box({
   content: "connecting..."
 });
 
-// Explicit height (not a bottom anchor) so blessed's list scroll math works;
-// "48%-3" makes it end exactly at the QSO panel's top (row 3 + height = 48%).
 const decodeList = blessed.list({
   top: 3,
   left: 0,
@@ -149,7 +121,6 @@ const decodeList = blessed.list({
   }
 });
 
-// The QSO panel holds a CQ indicator (top line) and the active QSO list.
 const qsoArea = blessed.box({ top: "48%", left: 0, width: "55%", height: "25%" });
 
 const cqIndicator = blessed.box({
@@ -180,8 +151,6 @@ const qsoList = blessed.list({
   style: { selected: { bg: "blue", fg: "black" } }
 });
 
-// Completed QSOs: bottom-left, under Active QSOs. Explicit height ("27%-3" ends
-// at 100%-3, above the command bar) keeps list scrolling working.
 const completedPanel = blessed.list({
   top: "73%",
   left: 0,
@@ -207,7 +176,7 @@ const composePanel = blessed.box({
   label: " compose "
 });
 
-const afLabel = blessed.text({ parent: composePanel, top: 0, left: 1, content: "AF:" });
+blessed.text({ parent: composePanel, top: 0, left: 1, content: "AF:" });
 const afWarning = blessed.text({
   parent: composePanel,
   top: 0,
@@ -234,9 +203,12 @@ afInput.on("click", () => {
   return false;
 });
 afInput.on("submit", () => {
+  const af = Number(afInput.getValue());
+  if (Number.isInteger(af)) {
+    controller.setAf(af);
+  }
   updateAfWarning();
   renderOccupancyPlots();
-  scheduleAutomation();
   screen.render();
 });
 
@@ -251,11 +223,8 @@ const surveyButton = blessed.button({
   content: "Survey TX slot (pause 1 cycle, find clear freq)",
   style: { fg: "black", bg: "cyan", focus: { bg: "blue" }, hover: { bg: "blue" } }
 });
-surveyButton.on("press", startSurvey);
+surveyButton.on("press", () => controller.survey());
 
-// Live per-slot occupancy strips, refreshed each RX period. The slot you TX in
-// stays stale until a Survey (or manual pause) lets the radio hear it; that
-// slot's label is starred.
 const evenPlot = blessed.text({ parent: composePanel, top: 5, left: 1, tags: true, content: "" });
 const oddPlot = blessed.text({ parent: composePanel, top: 6, left: 1, tags: true, content: "" });
 
@@ -270,23 +239,17 @@ const slotButton = blessed.button({
   content: "slot: even (click to toggle)",
   align: "center"
 });
-let currentSlot: TxSlot = "even";
 slotButton.on("press", () => {
-  currentSlot = currentSlot === "even" ? "odd" : "even";
-  slotButton.setContent(`slot: ${currentSlot} (click to toggle)`);
-  updateAfWarning();
-  renderOccupancyPlots();
-  screen.render();
+  controller.setSlot(state.af.slot === "even" ? "odd" : "even");
 });
 
-// No manual message composition: a target callsign drives Reply QSO. Fill it by
-// double-clicking a decode (uses that message's sender) or by typing.
 const targetLabel = blessed.text({
   parent: composePanel,
   top: 10,
   left: 1,
   content: "target callsign (dbl-click a decode):"
 });
+void targetLabel;
 const targetInput = blessed.textbox({
   parent: composePanel,
   top: 11,
@@ -304,6 +267,8 @@ targetInput.on("click", () => {
   return false;
 });
 
+// Halt / resume. Halting cancels the current TX and disables automation (the
+// web client's model); pressing it again re-enables and resumes paused QSOs.
 const cancelButton = blessed.button({
   parent: composePanel,
   top: 14,
@@ -317,13 +282,11 @@ const cancelButton = blessed.button({
   style: { fg: "black", bg: "red" }
 });
 cancelButton.on("press", () => {
-  send({ type: "cancel_transmit" });
-  cancelSurvey("cancelled");
-  pendingAutomationTx = null;
-  manualOverridePending = false;
-  clearAutomationTimer();
-  automation.pauseAll("cancelled");
-  renderQsoList();
+  if (state.tx.enabled) {
+    controller.haltTx();
+  } else {
+    controller.setTxEnabled(true);
+  }
 });
 
 // --- qso automation controls ---------------------------------------------
@@ -347,27 +310,20 @@ function opButton(top: number, left: string | number, content: string, handler: 
 
 opButton(19, 1, "Call CQ", callCq);
 opButton(19, "48%", "Reply QSO", replyToTarget);
-opButton(20, 1, "Resume", () => actOnSelected((qso) => automation.resume(qso.id)));
-opButton(20, "48%", "Complete", () => {
-  const qso = selectedQso();
-  if (qso) {
-    handleQsoEvents(automation.complete(qso.id));
-    scheduleAutomation();
-  }
-});
+opButton(20, 1, "Resume", () => actOnSelected("resume"));
+opButton(20, "48%", "Complete", () => actOnSelected("complete"));
 opButton(21, 1, "Abandon", () => {
-  const qso = selectedQso();
-  if (qso) {
-    automation.abandon(qso.id);
+  const id = selectedQsoId;
+  if (id) {
+    controller.qsoAction(id, "abandon");
     selectedQsoId = null;
-    scheduleAutomation();
   }
 });
-opButton(21, "48%", "Retry", () => actOnSelected((qso) => automation.resetAttempts(qso.id)));
-opButton(22, 1, "Prev step", () => actOnSelected((qso) => automation.previousStep(qso.id)));
-opButton(22, "48%", "Next step", () => actOnSelected((qso) => automation.nextStep(qso.id)));
-opButton(23, 1, "Up", () => moveSelected(-1));
-opButton(23, "48%", "Down", () => moveSelected(1));
+opButton(21, "48%", "Retry", () => actOnSelected("retry"));
+opButton(22, 1, "Prev step", () => actOnSelected("prevStep"));
+opButton(22, "48%", "Next step", () => actOnSelected("nextStep"));
+opButton(23, 1, "Up", () => actOnSelected("moveUp"));
+opButton(23, "48%", "Down", () => actOnSelected("moveDown"));
 
 const logBox = blessed.log({
   top: "73%",
@@ -389,12 +345,9 @@ const commandBar = blessed.box({
   label: " commands "
 });
 
-// One button per daemon command. The Session button toggles start/stop and
-// auto-claims control; Release hands control back. Commands that need arguments
-// (save) open a dialog pre-filled from current status; the rest send at once.
 const commandButtons: Array<{ id?: string; label: string; run: () => void }> = [
   { id: "session", label: "▶ start", run: toggleSession },
-  { label: "release", run: releaseControl },
+  { label: "release", run: () => controller.releaseControl() },
   { label: "status", run: () => send({ type: "get_status" }) },
   { label: "config", run: () => send({ type: "get_config" }) },
   { label: "devices", run: () => send({ type: "list_audio_devices" }) },
@@ -420,55 +373,26 @@ commandButtons.forEach((command, index) => {
     sessionButton = button;
   }
 });
-renderSessionButton();
 
 // --- control workflow -----------------------------------------------------
 
-// Ensure we hold control before a state-changing command. Auto-claims when
-// control is free; refuses (with a friendly message) when another client holds
-// it. The daemon processes the claim before the command sent right after it, so
-// controlMine need not be updated yet for the follow-up command to succeed.
-function ensureControl(): boolean {
-  if (controlMine) {
-    return true;
-  }
-  if (controlHeld) {
-    appendLog("You do not have control (another client holds it)");
-    return false;
-  }
-  send({ type: "claim_control", ...(token ? { token } : {}) });
-  return true;
-}
-
 function toggleSession(): void {
-  if (!ensureControl()) {
-    return;
+  if (state.station.sessionActive) {
+    controller.stopSession();
+  } else {
+    controller.startSession();
   }
-  if (!sessionActive && !configComplete) {
-    appendLog("Complete station config first (command: save)");
-    return;
-  }
-  send(sessionActive ? { type: "stop_session" } : { type: "start_session" });
 }
 
-function releaseControl(): void {
-  if (!controlMine) {
-    appendLog(controlHeld ? "You do not have control (another client holds it)" : "control is not held");
-    return;
-  }
-  send({ type: "release_control" });
-}
-
-// Label/colour the Session toggle from the live session state: green ▶ start
-// when idle, red ■ stop while a session is running.
 function renderSessionButton(): void {
   if (!sessionButton) {
     return;
   }
-  sessionButton.setContent(sessionActive ? "■ stop" : configComplete ? "▶ start" : "▶ setup first");
-  sessionButton.style.bg = sessionActive ? "red" : configComplete ? "green" : "yellow";
+  const active = state.station.sessionActive;
+  const complete = state.setup.complete;
+  sessionButton.setContent(active ? "■ stop" : complete ? "▶ start" : "▶ setup first");
+  sessionButton.style.bg = active ? "red" : complete ? "green" : "yellow";
   sessionButton.style.fg = "black";
-  screen.render();
 }
 
 screen.append(statusBar);
@@ -495,16 +419,12 @@ decodeList.on("select", (_item, index) => {
   const doubleClick = index === lastBandClickIndex && now - lastBandClickTime < 500;
   lastBandClickIndex = index;
   lastBandClickTime = now;
-
-  // Double click: start a reply QSO for this message's sender. Do not touch the
-  // operator's AF field; a double click arrives as two list selections.
   if (doubleClick) {
     replyToDecode(record);
   }
   screen.render();
 });
 
-// 'r' replies to the selected decode's sender, or falls back to the target box.
 decodeList.key(["r"], () => {
   const index = (decodeList as unknown as { selected: number }).selected;
   const row = bandRows[index];
@@ -516,9 +436,6 @@ decodeList.key(["r"], () => {
 });
 decodeList.key(["c"], callCq);
 
-// Replace blessed's default list wheel (which moves the selection and snaps the
-// view back to it) with a plain viewport scroll, so wheeling starts from where
-// you are looking — the bottom — rather than the stale selection.
 const bandScroll = decodeList as unknown as { scroll(offset: number): void };
 decodeList.removeAllListeners("element wheeldown");
 decodeList.removeAllListeners("element wheelup");
@@ -541,26 +458,23 @@ function trackQsoSelection(): void {
 qsoList.on("select item", trackQsoSelection);
 qsoList.on("select", trackQsoSelection);
 qsoList.key(["c"], callCq);
-qsoList.key(["u", "S-up"], () => moveSelected(-1));
-qsoList.key(["d", "S-down"], () => moveSelected(1));
+qsoList.key(["u", "S-up"], () => actOnSelected("moveUp"));
+qsoList.key(["d", "S-down"], () => actOnSelected("moveDown"));
 
-function senderOf(message: string): string | null {
-  const parsed = parseFt8Message(message);
-  if (!parsed) {
-    return null;
-  }
-  return parsed.type === "cq" ? parsed.call : parsed.from;
+// --- input actions (routed to the controller) -----------------------------
+
+function callCq(): void {
+  controller.callCq(state.af.slot);
 }
 
-function gridFrom(message: string): string | null {
-  const parsed = parseFt8Message(message);
-  if (!parsed) {
-    return null;
+function replyToTarget(): void {
+  const call = targetInput.getValue().trim().toUpperCase();
+  if (!call) {
+    appendLog("enter a target callsign (or double-click a decode)");
+    return;
   }
-  if (parsed.type === "cq") {
-    return parsed.grid;
-  }
-  return parsed.payload.type === "grid" ? parsed.payload.grid : null;
+  targetInput.clearValue();
+  controller.replyToCall(call);
 }
 
 function replyToDecode(record: DecodeRecord): void {
@@ -569,34 +483,34 @@ function replyToDecode(record: DecodeRecord): void {
     appendLog("selected decode has no sender callsign");
     return;
   }
-  replyToCall(sender, oppositeSlot(slotFromTimestamp(record.ts)), gridFrom(record.message));
+  // The controller derives the reply slot and their grid from its own decode
+  // buffer, so the TUI only has to name the station.
+  controller.replyToCall(sender);
 }
 
-function findLastDecodeFrom(call: string): DecodeRecord | null {
-  for (let index = decodes.length - 1; index >= 0; index--) {
-    if (senderOf(decodes[index]!.message) === call) {
-      return decodes[index]!;
-    }
+function actOnSelected(action: Parameters<typeof controller.qsoAction>[1]): void {
+  if (selectedQsoId) {
+    controller.qsoAction(selectedQsoId, action);
   }
-  return null;
 }
 
-// Each active QSO gets a stable colour, used to tint its decodes in Band
-// Activity and mark its row. Yellow is reserved for "replying to me".
+// --- rendering ------------------------------------------------------------
+
 const QSO_PALETTE = ["cyan", "magenta", "green", "blue", "red", "white"];
 const qsoColors = new Map<string, string>();
 let nextQsoColor = 0;
-function colorForQso(qso: QsoRecord): string {
-  let color = qsoColors.get(qso.id);
+function colorForQso(id: string): string {
+  let color = qsoColors.get(id);
   if (!color) {
     color = QSO_PALETTE[nextQsoColor % QSO_PALETTE.length]!;
     nextQsoColor++;
-    qsoColors.set(qso.id, color);
+    qsoColors.set(id, color);
   }
   return color;
 }
 
 function mentionsMyCall(message: string): boolean {
+  const myCall = state.station.call;
   if (!myCall) {
     return false;
   }
@@ -622,21 +536,19 @@ function pushBandSeparator(periodStart: number, youTx: boolean): void {
 }
 
 function decodeMarkup(message: string, line: string): string {
-  // Someone replying to me stays yellow, regardless of any QSO colour.
   if (mentionsMyCall(message)) {
     return `{black-fg}{yellow-bg}${line}{/yellow-bg}{/black-fg}`;
   }
   const sender = senderOf(message);
   if (sender) {
-    const qso = automation.qsos.find(
+    const qso = state.qsos.active.find(
       (candidate) => candidate.kind === "standard" && candidate.theirCall === sender && candidate.status !== "complete"
     );
     if (qso) {
-      const color = colorForQso(qso);
+      const color = colorForQso(qso.id);
       return `{black-fg}{${color}-bg}${line}{/${color}-bg}{/black-fg}`;
     }
-    // Already worked (in the log): grey it out so we don't call them again.
-    if (workedCalls.has(sender)) {
+    if (state.workedCalls.has(sender)) {
       return `{grey-fg}${line}{/grey-fg}`;
     }
   }
@@ -652,8 +564,6 @@ function appendBandDecode(record: DecodeRecord): void {
   decodeList.scrollTo(bandRows.length);
 }
 
-// Our TX slot is deaf, so a cycle we transmit in has no decodes; show the TX
-// message there instead.
 function appendBandTx(ts: number, af: number, message: string): void {
   pushBandSeparator(Math.floor(ts / 15) * 15, true);
   bandRows.push({ kind: "tx" });
@@ -662,27 +572,23 @@ function appendBandTx(ts: number, af: number, message: string): void {
 }
 
 // --- cycle clock ----------------------------------------------------------
-// Shows the current even/odd 15s period, the countdown to the next boundary,
-// and whether we are transmitting. Ticks on a timer independent of daemon
-// messages so the countdown stays live.
 
 function clockSegment(): string {
-  if (!clock) {
+  const c = clock();
+  if (!c) {
     return "{grey-fg}awaiting slot clock{/grey-fg}";
   }
-  // Virtual seconds, not wall seconds: decode timestamps and the countdown must
-  // agree, and under a scaled engine only one of those is wall time.
-  const nowSec = Math.floor(clock.now() / 1000);
-  const slotSeconds = clock.spec.slotMs / 1000;
+  const nowSec = Math.floor(c.now() / 1000);
+  const slotSeconds = c.spec.slotMs / 1000;
   const parity = slotFromTimestamp(nowSec);
   const remain = slotSeconds - (nowSec % slotSeconds);
   let tx: string;
-  if (surveyActive) {
-    const left = Math.max(0, surveyEndSec - nowSec);
-    tx = `{cyan-fg}{bold}SURVEY ${surveySlot} t-${left}s{/bold}{/cyan-fg}`;
-  } else if (latestTxState === "active") {
+  if (state.survey.active) {
+    const left = Math.max(0, state.survey.endSec - nowSec);
+    tx = `{cyan-fg}{bold}SURVEY ${state.survey.slot} t-${left}s{/bold}{/cyan-fg}`;
+  } else if (state.tx.state === "active") {
     tx = "{red-fg}{bold}TX{/bold}{/red-fg}";
-  } else if (latestTxState === "pending") {
+  } else if (state.tx.state === "pending") {
     tx = "{yellow-fg}TX-arm{/yellow-fg}";
   } else {
     tx = "{green-fg}RX{/green-fg}";
@@ -691,119 +597,15 @@ function clockSegment(): string {
 }
 
 function renderStatusBar(): void {
+  const dialFreqHz = state.station.dialFreqHz;
   const qrg = dialFreqHz
     ? `{green-fg}${(dialFreqHz / 1e6).toFixed(3)}MHz{/green-fg}`
     : "{yellow-fg}unset{/yellow-fg}";
-  // Unmissable: a simulated QSO that an operator mistakes for a real one gets
-  // logged, and a fabricated contact uploaded to LoTW cannot be taken back.
-  const demo =
-    engineKind === "simulated" ? "{black-fg}{yellow-bg} DEMO — NOT ON THE AIR {/}  ||  " : "";
+  const demo = state.station.demo ? "{black-fg}{yellow-bg} DEMO — NOT ON THE AIR {/}  ||  " : "";
   statusBar.setContent(`${demo}${statusBase}  ||  ${clockSegment()}  ||  QRG=${qrg}`);
-  screen.render();
 }
 
-function setDialFreqHz(value: number | null): void {
-  dialFreqHz = value;
-  renderStatusBar();
-  void persistTuiState();
-}
-
-async function persistTuiState(): Promise<void> {
-  try {
-    await writeTuiState({ dialFreqHz });
-  } catch (error) {
-    appendLog(`[state error] ${error instanceof Error ? error.message : String(error)}`);
-  }
-}
-
-// --- qso automation helpers ----------------------------------------------
-
-function ensureAutomationIdentity(): boolean {
-  if (!myCall || !myGrid) {
-    appendLog("automation requires configured callsign and grid");
-    return false;
-  }
-  return true;
-}
-
-function callCq(): void {
-  if (!ensureAutomationIdentity()) {
-    return;
-  }
-  automation.createCq(myCall, myGrid, currentSlot, "top");
-  appendLog("[qso] calling CQ");
-  renderQsoList();
-  scheduleAutomation();
-}
-
-function replyToTarget(): void {
-  if (!ensureAutomationIdentity()) {
-    return;
-  }
-  const call = targetInput.getValue().trim().toUpperCase();
-  if (!call) {
-    appendLog("enter a target callsign (or double-click a decode)");
-    return;
-  }
-  // Best-guess reply slot and their grid from the most recent decode of them.
-  const last = findLastDecodeFrom(call);
-  replyToCall(call, last ? oppositeSlot(slotFromTimestamp(last.ts)) : currentSlot, last ? gridFrom(last.message) : null);
-}
-
-function replyToCall(call: string, nextSlot: TxSlot, theirGrid: string | null): void {
-  if (!ensureAutomationIdentity()) {
-    return;
-  }
-  const normalizedCall = call.trim().toUpperCase();
-  if (!/^[A-Z0-9/]{2,}$/.test(normalizedCall)) {
-    appendLog(`'${normalizedCall}' is not a valid callsign`);
-    return;
-  }
-  const existing = automation.qsos.find(
-    (qso) => qso.kind === "standard" && qso.theirCall === normalizedCall && qso.status !== "complete"
-  );
-  if (existing) {
-    appendLog(`QSO already exists for ${normalizedCall}`);
-    selectQso(existing.id);
-    return;
-  }
-  const qso = automation.createReplyToCall(normalizedCall, myCall, myGrid, nextSlot, theirGrid, "top");
-  colorForQso(qso);
-  appendLog(`[qso] reply to ${qso.theirCall}`);
-  targetInput.clearValue();
-  selectQso(qso.id);
-  scheduleAutomation();
-}
-
-function selectedQso(): QsoRecord | null {
-  if (!selectedQsoId) {
-    return null;
-  }
-  return automation.qsos.find((qso) => qso.id === selectedQsoId) ?? null;
-}
-
-function selectQso(id: string | null): void {
-  selectedQsoId = id;
-  renderQsoList();
-}
-
-function actOnSelected(action: (qso: QsoRecord) => unknown): void {
-  const qso = selectedQso();
-  if (!qso) {
-    return;
-  }
-  action(qso);
-  scheduleAutomation();
-}
-
-function moveSelected(delta: -1 | 1): void {
-  const qso = selectedQso();
-  if (!qso) {
-    return;
-  }
-  automation.move(qso.id, delta);
-  scheduleAutomation();
-}
+// --- qso list -------------------------------------------------------------
 
 function formatQsoRow(qso: QsoRecord, priority: number): string {
   const who = qso.theirCall ?? "CQ";
@@ -811,7 +613,7 @@ function formatQsoRow(qso: QsoRecord, priority: number): string {
   const preview = messageForQso(qso) ?? "-";
   const lastRx = qso.rxMessages[qso.rxMessages.length - 1]?.message ?? "-";
   const note = qso.note ? ` (${qso.note})` : "";
-  const color = colorForQso(qso);
+  const color = colorForQso(qso.id);
   const dot = `{${color}-fg}●{/${color}-fg}`;
   const base = `${priority} ${qso.status} ${who} ${qso.step} att=${attempts} rx>${lastRx} tx>${preview}${note}`;
   switch (qso.status) {
@@ -831,22 +633,16 @@ function formatCompletedRow(qso: QsoRecord): string {
   return `{green-fg}✓ ${qso.theirCall ?? "?"}${grid} ${reports}{/green-fg}`;
 }
 
-function renderCqIndicator(): void {
-  cqIndicator.setContent(
-    automation.isCallingCq()
-      ? "{green-bg}{black-fg} ● CALLING CQ {/black-fg}{/green-bg}"
-      : "{grey-fg}○ CQ idle — press Call CQ to start{/grey-fg}"
-  );
-}
-
-// Active QSOs exclude the hidden CQ row (shown via the indicator) and completed
-// QSOs (shown in their own list). renderedActive maps list rows to records.
 let renderedActive: QsoRecord[] = [];
 
 function renderQsoList(): void {
-  renderCqIndicator();
+  cqIndicator.setContent(
+    state.qsos.callingCq
+      ? "{green-bg}{black-fg} ● CALLING CQ {/black-fg}{/green-bg}"
+      : "{grey-fg}○ CQ idle — press Call CQ to start{/grey-fg}"
+  );
 
-  renderedActive = automation.qsos.filter((qso) => qso.kind !== "calling-cq" && qso.status !== "complete");
+  renderedActive = state.qsos.active.filter((qso) => qso.kind !== "calling-cq" && qso.status !== "complete");
   qsoList.setItems(renderedActive.map((qso, index) => formatQsoRow(qso, index + 1)));
   if (selectedQsoId) {
     const index = renderedActive.findIndex((qso) => qso.id === selectedQsoId);
@@ -857,60 +653,10 @@ function renderQsoList(): void {
     }
   }
 
-  renderCompleted();
-
-  screen.render();
+  completedPanel.setItems(state.qsos.completed.map(formatCompletedRow));
 }
 
-function renderCompleted(): void {
-  completedPanel.setItems(automation.qsos.filter((qso) => qso.status === "complete").map(formatCompletedRow));
-}
-
-function handleQsoEvents(events: QsoAutomationEvent[]): void {
-  for (const event of events) {
-    switch (event.type) {
-      case "qso_created":
-        colorForQso(event.qso);
-        appendLog(`[qso] created ${event.qso.theirCall ?? "CQ"}`);
-        break;
-      case "qso_updated":
-        appendLog(`[qso] ${event.qso.theirCall} ${event.previousStep} -> ${event.qso.step}`);
-        break;
-      case "qso_completed":
-        appendLog(`[qso] complete ${event.qso.theirCall ?? "CQ"} (${event.reason})`);
-        void logCompletedQso(event.qso, event.reason);
-        break;
-      case "qso_timed_out":
-        appendLog(`[qso] timed out ${event.qso.theirCall ?? "CQ"} step=${event.qso.step}`);
-        break;
-      case "cq_stopped":
-        appendLog("[qso] CQ stopped after reply");
-        break;
-    }
-  }
-  renderQsoList();
-}
-
-async function logCompletedQso(qso: QsoRecord, reason: string): Promise<void> {
-  if (loggedQsoIds.has(qso.id)) {
-    return;
-  }
-  const entry = automation.toLogEntry(qso, reason, dialFreqHz);
-  if (!entry) {
-    return;
-  }
-  loggedQsoIds.add(qso.id);
-  try {
-    await appendQsoLog(entry, qsoLogPathFor(engineKind));
-    workedCalls.add(entry.theirCall);
-    appendLog(`[qso-log] wrote ${entry.theirCall}${dialFreqHz ? ` @${(dialFreqHz / 1e6).toFixed(3)}MHz` : " (no freq set)"}`);
-  } catch (error) {
-    loggedQsoIds.delete(qso.id);
-    appendLog(`[qso-log error] ${error instanceof Error ? error.message : String(error)}`);
-  }
-}
-
-// --- occupied AF warning --------------------------------------------------
+// --- occupancy plots + AF warning -----------------------------------------
 
 function updateAfWarning(): void {
   const af = Number(afInput.getValue());
@@ -918,220 +664,45 @@ function updateAfWarning(): void {
     afWarning.setContent("");
     return;
   }
-  const match = findOccupiedAf(decodes, af, currentSlot, 50, 2);
+  const match = findOccupiedAf(decodes, af, state.af.slot, 50, 2);
   afWarning.setContent(
     match ? `{yellow-fg}occupied +/-50Hz: ${match.decode.af} ${match.decode.message}{/yellow-fg}` : ""
   );
 }
 
-// The slot we transmit in: the active CQ row's slot, else the manual slot.
-function currentTxSlot(): TxSlot {
-  const cq = automation.qsos.find((qso) => qso.kind === "calling-cq" && qso.status === "active");
-  return cq ? cq.nextSlot : currentSlot;
-}
-
-// AFs decoded in the most recent RX period of the given parity ("the last set
-// of decodes" for that slot). Empty until a period of that parity is heard.
-function latestSlotAfs(parity: TxSlot): number[] {
-  let latestStart = -1;
-  for (const decode of decodes) {
-    if (slotFromTimestamp(decode.ts) !== parity) {
-      continue;
-    }
-    const start = Math.floor(decode.ts / 15) * 15;
-    if (start > latestStart) {
-      latestStart = start;
-    }
-  }
-  if (latestStart < 0) {
-    return [];
-  }
-  return decodes.filter((decode) => Math.floor(decode.ts / 15) * 15 === latestStart).map((decode) => decode.af);
-}
-
 function renderOccupancyPlots(): void {
   const afValue = Number(afInput.getValue());
   const mark = Number.isInteger(afValue) ? afValue : undefined;
-  const txSlot = currentTxSlot();
-  const even = renderOccupancyBar(latestSlotAfs("even"), SURVEY_LO_HZ, SURVEY_HI_HZ, PLOT_WIDTH, mark);
-  const odd = renderOccupancyBar(latestSlotAfs("odd"), SURVEY_LO_HZ, SURVEY_HI_HZ, PLOT_WIDTH, mark);
+  const txSlot = state.af.slot;
+  const even = renderOccupancyBar(latestSlotAfs(decodes, "even"), SURVEY_LO_HZ, SURVEY_HI_HZ, PLOT_WIDTH, mark);
+  const odd = renderOccupancyBar(latestSlotAfs(decodes, "odd"), SURVEY_LO_HZ, SURVEY_HI_HZ, PLOT_WIDTH, mark);
   evenPlot.setContent(`${txSlot === "even" ? "{bold}E*{/bold}" : "E "}|${even}|`);
   oddPlot.setContent(`${txSlot === "odd" ? "{bold}O*{/bold}" : "O "}|${odd}|`);
 }
 
-// --- scheduler ------------------------------------------------------------
-
-function currentAfOrNull(): number | null {
-  const af = Number(afInput.getValue());
-  if (!Number.isInteger(af) || af < 200 || af > 3000) {
-    return null;
-  }
-  return af;
-}
-
-function clearAutomationTimer(): void {
-  if (automationTimer) {
-    clearTimeout(automationTimer);
-    automationTimer = null;
-  }
-}
-
-// The daemon rests in "pending" after a transmission (its desiredTx lingers
-// until cancel/clear), so we can never rely on seeing "idle" to resume. Re-arm
-// automation on the falling edge of "active" (a transmission just finished), or
-// on a genuine "idle" (e.g. after cancel).
-function updateTxState(next: "idle" | "pending" | "active"): void {
-  const wasActive = latestTxState === "active";
-  latestTxState = next;
-  if (manualOverridePending || surveyActive || next === "active") {
-    return;
-  }
-  if (wasActive || next === "idle") {
-    scheduleAutomation();
-  }
-}
-
-function scheduleAutomation(): void {
-  clearAutomationTimer();
-  renderQsoList();
-  updateAfWarning();
-
-  if (!sessionActive || surveyActive || manualOverridePending || latestTxState === "active") {
-    return;
-  }
-
-  const af = currentAfOrNull();
-  if (af === null) {
-    return;
-  }
-
-  const tx = automation.nextTransmission(af);
-  if (!tx) {
-    return;
-  }
-
-  if (!clock) {
-    appendLog("[automation] paused: awaiting the slot clock from the daemon");
-    return;
-  }
-
-  // Arm two virtual seconds before the slot opens. The clock converts that
-  // virtual lead into the wall delay setTimeout actually needs.
-  automationTimer = setTimeout(
-    () => sendAutomatedTx(tx),
-    clock.wallDelayUntilSlot(tx.intent.slot, AUTOMATION_LEAD_SECONDS)
-  );
-}
-
-function sendAutomatedTx(tx: AutomationTx): void {
-  automationTimer = null;
-  if (!sessionActive || surveyActive || manualOverridePending || latestTxState === "active") {
-    return;
-  }
-  const af = currentAfOrNull();
-  if (af === null) {
-    appendLog("automation paused: invalid AF");
-    return;
-  }
-
-  const refreshed: AutomationTx = {
-    ...tx,
-    intent: { ...tx.intent, af }
-  };
-
-  pendingAutomationTx = refreshed;
-  send({ type: "transmit", ...refreshed.intent });
-  renderQsoList();
-}
-
-// --- slot survey ----------------------------------------------------------
-
-function startSurvey(): void {
-  if (surveyActive) {
-    appendLog("[survey] already running");
-    return;
-  }
-  // Our TX parity is the active CQ row's slot, falling back to the manual slot.
-  const cq = automation.qsos.find((qso) => qso.kind === "calling-cq" && qso.status === "active");
-  const slot: TxSlot = cq ? cq.nextSlot : currentSlot;
-
-  surveyActive = true;
-  surveySlot = slot;
-  surveyStartSec = clock ? Math.floor(clock.now() / 1000) : 0;
-
-  // Stop transmitting so the radio can actually hear its own TX slot: drop any
-  // armed timer and cancel a queued (not yet keyed) automated transmit.
-  clearAutomationTimer();
-  if (pendingAutomationTx) {
-    send({ type: "cancel_transmit" });
-    pendingAutomationTx = null;
-  }
-
-  if (!clock) {
-    appendLog("[survey] unavailable: awaiting the slot clock from the daemon");
-    surveyActive = false;
-    return;
-  }
-
-  // Wait for the next full receive cycle of this parity, plus decode latency.
-  // That is a negative offset -- past the boundary, not before it -- and the slot
-  // length comes from the clock, never a literal 15.
-  const slotSeconds = clock.spec.slotMs / 1000;
-  const pastBoundary = slotSeconds + SURVEY_DECODE_LAG_SECONDS;
-  const delaySec = clock.secondsUntilSlot(slot) + pastBoundary;
-  surveyEndSec = clock.virtualDeadlineAfter(delaySec);
-  appendLog(`[survey] holding TX ~${delaySec}s to listen on the ${slot} slot`);
-  updateSurveyButton();
-  renderStatusBar();
-  if (surveyTimer) {
-    clearTimeout(surveyTimer);
-  }
-  surveyTimer = setTimeout(finishSurvey, clock.wallDelayUntilSlot(slot, -pastBoundary));
-}
-
-function finishSurvey(): void {
-  surveyTimer = null;
-  const slot = surveySlot;
-  surveyActive = false;
-  surveySlot = null;
-
-  if (slot) {
-    // The held cycle refreshed this slot's plot; auto-pick the widest clear gap.
-    const occupied = latestSlotAfs(slot);
-    const suggestion = suggestClearAf(occupied, SURVEY_LO_HZ, SURVEY_HI_HZ);
-    afInput.setValue(String(suggestion));
-    appendLog(`[survey] ${slot} slot updated, clear@${suggestion}Hz (${occupied.length} sigs)`);
-  }
-
-  updateSurveyButton();
-  renderOccupancyPlots();
-  renderStatusBar();
-  scheduleAutomation();
-}
-
-function cancelSurvey(reason: string): void {
-  if (!surveyActive) {
-    return;
-  }
-  if (surveyTimer) {
-    clearTimeout(surveyTimer);
-    surveyTimer = null;
-  }
-  surveyActive = false;
-  surveySlot = null;
-  appendLog(`[survey] aborted (${reason})`);
-  updateSurveyButton();
-  renderStatusBar();
-}
-
 function updateSurveyButton(): void {
-  if (surveyActive) {
+  if (state.survey.active) {
     surveyButton.setContent("SURVEYING… (CANCEL TX to stop)");
     surveyButton.style.bg = "red";
   } else {
     surveyButton.setContent("Survey TX slot (find clear freq)");
     surveyButton.style.bg = "cyan";
   }
+}
+
+function renderSlotButton(): void {
+  slotButton.setContent(`slot: ${state.af.slot} (click to toggle)`);
+}
+
+// Redraw everything that derives from a controller snapshot.
+function renderFromState(): void {
+  renderQsoList();
+  renderSessionButton();
+  renderSlotButton();
+  updateSurveyButton();
+  updateAfWarning();
+  renderOccupancyPlots();
+  renderStatusBar();
   screen.render();
 }
 
@@ -1139,8 +710,6 @@ function updateSurveyButton(): void {
 
 let dialogOpen = false;
 
-// Modal form: a labelled textbox per field plus OK/Cancel. Pre-filled values
-// are shown so the operator can accept or edit them.
 function openDialog(
   title: string,
   fields: Array<{ name: string; label: string; value: string }>,
@@ -1223,7 +792,6 @@ function openDialog(
   ok.key(["enter", "space"], submit);
   cancel.key(["enter", "space"], close);
 
-  // Enter advances to the next field; from the last field it moves to OK.
   inputs.forEach((input, index) => {
     input.on("submit", () => {
       focusDialogField(inputs[index + 1] ?? ok);
@@ -1257,10 +825,6 @@ function focusDialogField(field: blessed.Widgets.BlessedElement): void {
   focusFieldWithoutInputTrap(field);
 }
 
-// Focus a field, defeating blessed's inputOnFocus "focus trap": a textbox that
-// is still reading rewinds focus back to itself on blur, which can instantly
-// blur the field we are trying to focus. Disabling inputOnFocus on the mid-read
-// textbox while we take focus stops the rewind; we restore it after.
 function focusFieldWithoutInputTrap(field: blessed.Widgets.BlessedElement): void {
   if (screen.focused === field) {
     return;
@@ -1281,8 +845,8 @@ function openSaveDialog(): void {
     "save config",
     [
       { name: "deviceId", label: "device id", value: lastDeviceId != null ? String(lastDeviceId) : "" },
-      { name: "callsign", label: "callsign", value: myCall },
-      { name: "grid", label: "grid", value: myGrid },
+      { name: "callsign", label: "callsign", value: state.station.call },
+      { name: "grid", label: "grid", value: state.station.grid },
       { name: "catMode", label: "cat mode (rigctld|dummy)", value: "rigctld" },
       { name: "catPort", label: "cat port", value: "4532" }
     ],
@@ -1292,38 +856,35 @@ function openSaveDialog(): void {
         appendLog("save: device id, callsign, grid, and cat mode are required");
         return;
       }
-      send({
-        type: "save_config",
-        session: {
-          mode: "FT8",
-          device: { id: deviceId },
-          callsign: values.callsign,
-          grid: values.grid,
-          cat: { mode: values.catMode, port: values.catPort ? Number(values.catPort) : 4532 }
-        }
+      controller.saveSetup({
+        deviceId,
+        callsign: values.callsign!,
+        grid: values.grid!,
+        catMode: values.catMode!,
+        catPort: values.catPort ? Number(values.catPort) : 4532
       });
-      configComplete = true;
-      renderSessionButton();
       appendLog(`[save] device=${deviceId} ${values.callsign} ${values.grid} ${values.catMode}`);
     }
   );
 }
 
-// Operating (dial) frequency: entered manually because CAT reports the wrong
-// band on this setup. Stored in Hz; logged with each QSO and used for export.
 function openFreqDialog(): void {
   openDialog(
     "operating frequency",
-    [{ name: "mhz", label: "dial freq MHz (e.g. 14.074)", value: dialFreqHz ? (dialFreqHz / 1e6).toFixed(3) : "" }],
+    [
+      {
+        name: "mhz",
+        label: "dial freq MHz (e.g. 14.074)",
+        value: state.station.dialFreqHz ? (state.station.dialFreqHz / 1e6).toFixed(3) : ""
+      }
+    ],
     (values) => {
       const mhz = Number(values.mhz);
       if (!Number.isFinite(mhz) || mhz <= 0) {
         appendLog("freq: enter a positive frequency in MHz (e.g. 14.074)");
         return;
       }
-      setDialFreqHz(Math.round(mhz * 1e6));
-      const band = bandForMHz(mhz);
-      appendLog(`[freq] operating dial freq = ${mhz.toFixed(3)} MHz${band ? ` (${band})` : " (out of ham band?)"}`);
+      controller.setDialFreq(mhz);
     }
   );
 }
@@ -1365,151 +926,30 @@ async function exportAdif(path: string): Promise<void> {
   }
 }
 
-// --- websocket event handling ---------------------------------------------
+// --- raw daemon stream (Band Activity rendering only) ---------------------
 
 client.on("open", () => {
   appendLog(`connected to ${url}`);
-  send({ type: "get_config" });
   decodeList.focus();
   screen.render();
-});
-
-client.on("close", () => {
-  sessionActive = false;
-  clock = null;
-  engineKind = "ft8cat";
-  clearAutomationTimer();
-  automation.qsos.splice(0);
-  appendLog("connection closed");
-  screen.render();
-});
-
-client.on("status", (msg) => {
-  const { session, tx, control } = msg;
-  const previousActive = sessionActive;
-  const previousKind = engineKind;
-  const previousClock = clock;
-
-  // Adopt the daemon's clock. Any field change (not just scale) can move the
-  // next boundary, so drop timers rather than leaving them at a stale anchor.
-  const clockDirty =
-    previousClock === null ||
-    previousClock.spec.epochMs !== msg.clock.epochMs ||
-    previousClock.spec.anchorWallMs !== msg.clock.anchorWallMs ||
-    previousClock.spec.slotMs !== msg.clock.slotMs ||
-    previousClock.spec.scale !== msg.clock.scale;
-  clock = new SlotClock(msg.clock);
-  engineKind = msg.engine;
-
-  const sessionEnded = previousActive && !session.active;
-  const kindChanged = previousKind !== msg.engine;
-  if (sessionEnded || kindChanged) {
-    clearAutomationTimer();
-    automation.qsos.splice(0);
-  } else if (clockDirty) {
-    clearAutomationTimer();
-  }
-
-  if (session.callsign !== null) {
-    myCall = session.callsign;
-  }
-  if (session.grid !== null) {
-    myGrid = session.grid;
-  }
-  if (session.device) {
-    lastDeviceId = session.device.id;
-  }
-  controlHeld = control.held;
-  controlMine = control.byThisClient;
-  sessionActive = session.active;
-  statusBase =
-    `{bold}active{/bold}=${session.active} device=${session.device?.id ?? "-"} ` +
-    `cat=${session.catConnected} freq=${session.freq ?? "-"} ptt=${session.ptt} call=${session.callsign ?? "-"} grid=${session.grid ?? "-"}  ||  ` +
-    `tx=${tx.state} af=${tx.af ?? "-"} slot=${tx.slot ?? "-"}  ||  control held=${control.held} mine=${control.byThisClient}`;
-  updateTxState(tx.state);
-  if (sessionActive && (clockDirty || (kindChanged && !sessionEnded))) {
-    scheduleAutomation();
-  }
-  renderSessionButton();
-  renderStatusBar();
 });
 
 client.on("decode", (msg) => {
   const record: DecodeRecord = { ts: msg.ts, snr: msg.snr, dt: msg.dt, af: msg.af, message: msg.message };
   decodes.push(record);
   appendBandDecode(record);
-  screen.render();
-
-  // Occupied-frequency info and the per-slot plots depend on decodes.
   updateAfWarning();
   renderOccupancyPlots();
-
-  // Only touch the scheduler when a decode actually advances a QSO. An
-  // unrelated decode must not re-arm (or re-fire) the active transmission,
-  // e.g. it must not keep re-triggering CQ while we wait for a reply.
-  const events = automation.handleDecode(record, myCall, myGrid);
-  if (events.length > 0) {
-    handleQsoEvents(events);
-    // A live QSO beats surveying: if a caller just answered, stop holding.
-    cancelSurvey("answering caller");
-    scheduleAutomation();
-  }
+  screen.render();
 });
 
 client.on("tx", (msg) => {
-  appendLog(`[tx] af=${msg.af} ${msg.message}`);
   appendBandTx(msg.ts, msg.af, msg.message);
-  if (manualOverridePending) {
-    manualOverridePending = false;
-    pendingAutomationTx = null;
-    scheduleAutomation();
-    return;
-  }
-  const result = automation.confirmTransmission(pendingAutomationTx, { ts: msg.ts, af: msg.af, message: msg.message });
-  if (result.matched) {
-    pendingAutomationTx = null;
-  }
-  if (result.events.length > 0) {
-    handleQsoEvents(result.events);
-  }
-  scheduleAutomation();
+  screen.render();
 });
 
 client.on("tx_update", (msg) => {
   appendLog(`[tx_update] state=${msg.state} af=${msg.af ?? "-"} slot=${msg.slot ?? "-"} msg=${msg.message ?? "-"}`);
-  updateTxState(msg.state);
-});
-
-client.on("log", (msg) => {
-  appendLog(`[${msg.level}] ${msg.message}`);
-});
-
-client.on("daemonError", (msg) => {
-  if (msg.code === "CONTROL_REQUIRED" || msg.code === "CONTROL_UNAVAILABLE") {
-    appendLog("You do not have control (another client holds it)");
-  } else {
-    appendLog(`[error] ${msg.code}: ${msg.message}${msg.details ? ` ${JSON.stringify(msg.details)}` : ""}`);
-  }
-  if (pendingAutomationTx) {
-    // Do not count this as an attempt; leave the QSO active and retry later.
-    pendingAutomationTx = null;
-    scheduleAutomation();
-  }
-});
-
-client.on("config", (msg) => {
-  configComplete = msg.complete;
-  if (msg.session?.callsign) {
-    myCall = msg.session.callsign;
-  }
-  if (msg.session?.grid) {
-    myGrid = msg.session.grid;
-  }
-  if (msg.session?.device?.id != null) {
-    lastDeviceId = msg.session.device.id;
-  }
-  appendLog(`[config] complete=${msg.complete} ${JSON.stringify(msg.session ?? msg.missing ?? "")}`);
-  renderSessionButton();
 });
 
 client.on("audio_devices", (msg) => {
@@ -1519,53 +959,39 @@ client.on("audio_devices", (msg) => {
   }
 });
 
-// Seed the worked-callsign set from the persisted log so already-worked
-// stations are greyed in Band Activity from the first decode.
-async function loadWorkedCalls(): Promise<void> {
-  try {
-    const entries = await readQsoLog();
-    for (const entry of entries) {
-      if (entry.theirCall) {
-        workedCalls.add(entry.theirCall.toUpperCase());
-      }
-    }
-    appendLog(`[qso-log] ${workedCalls.size} worked callsign(s) loaded`);
-  } catch (error) {
-    appendLog(`[qso-log error] ${error instanceof Error ? error.message : String(error)}`);
+// Track the device id for the save dialog pre-fill, and the status one-liner.
+client.on("status", (msg) => {
+  const { session, tx, control } = msg;
+  if (session.device) {
+    lastDeviceId = session.device.id;
   }
-}
+  statusBase =
+    `{bold}active{/bold}=${session.active} device=${session.device?.id ?? "-"} ` +
+    `cat=${session.catConnected} freq=${session.freq ?? "-"} ptt=${session.ptt} call=${session.callsign ?? "-"} grid=${session.grid ?? "-"}  ||  ` +
+    `tx=${tx.state} af=${tx.af ?? "-"} slot=${tx.slot ?? "-"}  ||  control held=${control.held} mine=${control.byThisClient}`;
+});
 
-async function loadStoredDialFreq(): Promise<void> {
-  try {
-    const state = await readTuiState();
-    if (state.dialFreqHz != null) {
-      dialFreqHz = state.dialFreqHz;
-      appendLog(`[freq] restored dial freq = ${(dialFreqHz / 1e6).toFixed(3)} MHz`);
-      renderStatusBar();
-      return;
-    }
-
-    const entries = await readQsoLog();
-    for (let index = entries.length - 1; index >= 0; index--) {
-      const loggedFreq = entries[index]!.dialFreqHz;
-      if (loggedFreq != null) {
-        setDialFreqHz(loggedFreq);
-        appendLog(`[freq] restored last logged dial freq = ${(loggedFreq / 1e6).toFixed(3)} MHz`);
-        return;
-      }
-    }
-  } catch (error) {
-    appendLog(`[state error] ${error instanceof Error ? error.message : String(error)}`);
+client.on("config", (msg) => {
+  if (msg.session?.device?.id != null) {
+    lastDeviceId = msg.session.device.id;
   }
-}
+});
 
-setInterval(() => {
-  renderOccupancyPlots();
-  renderStatusBar();
-}, 500);
-void loadStoredDialFreq();
-void loadWorkedCalls();
-renderOccupancyPlots();
-renderQsoList();
+client.on("close", () => {
+  // Band Activity is left in place; the engine resets its own state.
+  bandRows.length = 0;
+  lastBandPeriod = null;
+});
+
+// The engine drives everything else.
+controller.onChange((next) => {
+  state = next;
+  renderFromState();
+});
+
+setInterval(renderStatusBar, 500);
+setInterval(() => screen.render(), 500);
+
+renderFromState();
 screen.render();
-client.connect();
+controller.start();

--- a/ui/web/protocol.ts
+++ b/ui/web/protocol.ts
@@ -3,18 +3,31 @@
 // pushes a StateMessage view-model; the browser sends CommandMessages. Keep
 // these types in sync with the runtime shapes app.js reads/writes.
 
-import type { QsoStep, TxSlot } from "../../core/qso.js";
+import type { TxSlot } from "../../core/qso.js";
 import type { TxPublicState } from "../../core/protocol.js";
+// The decode/QSO/cycle view shapes moved to core/view-model.ts (rebuild plan W2)
+// so the view-model depends only on core. Re-exported here so the browser bridge
+// and app.js keep importing them from the web protocol module.
+import type {
+  ActiveQsoView,
+  CompletedQsoView,
+  CycleView,
+  DecodeView,
+  NowView,
+  RosterEntryView
+} from "../../core/view-model.js";
+export type {
+  ActiveQsoView,
+  CompletedQsoView,
+  CycleView,
+  DecodeKind,
+  DecodeView,
+  NowView,
+  RosterEntryView
+} from "../../core/view-model.js";
 
 // Aliased from the daemon contract so the browser view shares core's TX state.
 export type TxState = TxPublicState;
-
-// How a decoded/heard station is coloured in the band panel and rosters.
-//  - "reply"  : the message mentions our callsign (someone answering us)
-//  - "qso"    : the sender matches an active standard QSO (carries its colour)
-//  - "worked" : the sender is already in the QSO log
-//  - "normal" : everything else
-export type DecodeKind = "reply" | "qso" | "worked" | "normal";
 
 export interface StationView {
   call: string;
@@ -40,89 +53,6 @@ export interface SetupView {
   complete: boolean;
   missing: string[];
   devices: SetupDeviceView[];
-}
-
-export interface NowView {
-  txState: TxState;
-  txEnabled: boolean;
-  af: number | null;
-  slot: TxSlot | null;
-  message: string | null;
-  surveyActive: boolean;
-  surveySlot: TxSlot | null;
-  surveyEndSec: number;
-}
-
-export interface DecodeView {
-  ts: number;
-  snr: number;
-  af: number;
-  message: string;
-  from: string | null;
-  grid: string | null;
-  // Which slot this decode landed in, and the start of its cycle -- both
-  // computed server-side. The browser cannot import core/slot-clock.ts (it is a
-  // plain script with no build step), so it is never asked to derive slot math
-  // itself, and carries no slot length of its own.
-  slot: TxSlot;
-  cycleStart: number;
-  kind: DecodeKind;
-  color?: string;
-}
-
-export interface CycleView {
-  parity: TxSlot;
-  // The wall instant of the next slot boundary, already scale-corrected by the
-  // server. The browser counts down to it against its own (skew-corrected) wall
-  // clock, with no scale factor and no 15-second constant anywhere in it.
-  // Null before the daemon has published a clock -- the browser renders a
-  // neutral countdown rather than a confidently wrong one.
-  nextBoundaryWallMs: number | null;
-  // How long a slot lasts in wall time at the current scale -- what the browser
-  // needs to render the cycle progress bar without knowing the scale.
-  slotWallMs: number | null;
-  // How long a slot lasts in FT8 terms (15s). The countdown is rendered in these
-  // units at any scale, because an operator reasons in FT8 seconds, not in the
-  // wall seconds a sped-up test happens to run at.
-  slotSeconds: number | null;
-}
-
-export interface RosterEntryView {
-  call: string;
-  grid: string | null;
-  snr: number;
-  ageSec: number;
-  af: number;
-  kind: DecodeKind;
-  color?: string;
-}
-
-export interface ActiveQsoView {
-  id: string;
-  call: string | null;
-  grid: string | null;
-  priority: number;
-  kind: "hunted" | "caller";
-  stepKey: QsoStep;
-  status: string;
-  attempts: number;
-  slot: TxSlot;
-  heardAgoSec: number | null;
-  lastRx: string | null;
-  nextTx: string | null;
-  txing: boolean;
-  note: string | null;
-  color: string;
-}
-
-export interface CompletedQsoView {
-  id: string;
-  call: string | null;
-  grid: string | null;
-  sentReport: string | null;
-  receivedReport: string | null;
-  slot: TxSlot | null;
-  time: string;
 }
 
 export interface LogLineView {

--- a/ui/web/server.ts
+++ b/ui/web/server.ts
@@ -5,23 +5,17 @@ import { fileURLToPath } from "node:url";
 import type { Duplex } from "node:stream";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
 import { DaemonClient } from "../../core/daemon-client.js";
-import type { DaemonCommand, EngineKind } from "../../core/protocol.js";
+import type { EngineKind } from "../../core/protocol.js";
+import {
+  createOperatorController,
+  type ControllerState,
+  type OperatorController,
+  type QsoLogStore,
+  type StateStore
+} from "../../core/controller.js";
 import { appendQsoLog, qsoLogPathFor, readQsoLog } from "../qso-log.js";
 import { readTuiState, writeTuiState } from "../tui-state.js";
 import { bandForMHz } from "../adif.js";
-import {
-  QsoAutomation,
-  oppositeSlot,
-  parseFt8Message,
-  slotFromTimestamp,
-  suggestClearAf,
-  type AutomationTx,
-  type DecodeRecord,
-  type QsoAutomationEvent,
-  type QsoRecord,
-  type TxSlot
-} from "../../core/qso.js";
-import { SlotClock } from "../../core/slot-clock.js";
 import {
   annotateDecode,
   buildActiveQsoView,
@@ -29,12 +23,10 @@ import {
   buildCycleView,
   buildRosters,
   deriveTxCard,
-  gridFrom,
   latestSlotAfs,
-  senderOf,
   type AnnotateContext
 } from "../../core/view-model.js";
-import type { CommandMessage, LogLineView, SetupView, StateMessage, TxState } from "./protocol.js";
+import type { CommandMessage, LogLineView, StateMessage } from "./protocol.js";
 
 let daemonUrl = process.env.DIGI_DX_URL ?? "ws://127.0.0.1:8788";
 let token = process.env.DIGI_DX_AUTH_TOKEN;
@@ -55,73 +47,17 @@ export interface WebUiServerOptions {
   headless?: { demo?: boolean };
 }
 
-// --- controller state ------------------------------------------------------
+// --- engine + transport wiring ---------------------------------------------
 
-const decodes: DecodeRecord[] = [];
-// The automation is constructed once, at module load, long before any clock
-// arrives -- so its timestamp source is a late-bound closure over the clock we
-// adopt from the daemon. It throws rather than reaching for `Date.now()`: this
-// is the one place that decides every logged QSO's timestamp, and a silent
-// wall-time fallback here would log a scaled QSO in the wrong time base. Safe
-// because the daemon sends a status on connect, before any decode can arrive.
-const automation = new QsoAutomation(() => new Date(requireClock().now()));
-
-let myCall = "";
-let myGrid = "";
-let dialFreqHz: number | null = null;
-
-let controlHeld = false;
-let controlMine = false;
-let sessionActive = false;
-let catConnected = false;
-let configComplete = false;
-let configMissing: string[] = [];
-let setupDevices: SetupView["devices"] = [];
-
-let latestTxState: TxState = "idle";
-let pendingAutomationTx: AutomationTx | null = null;
-let activeAutomationTx: AutomationTx | null = null;
-let scheduledAutomationTx: AutomationTx | null = null;
-// The daemon is the authority on slot timing. We hold the clock it publishes and
-// derive every slot decision from it -- countdowns, TX windows, and the automation
-// timer. There is deliberately no wall-clock fallback: before the first status
-// message, and again after a reconnect, we have no clock, and a silent
-// `Date.now()` fallback is exactly the bug a scaled clock would hide.
-let clock: SlotClock | null = null;
-let engineKind: EngineKind = "ft8cat";
-
-function requireClock(): SlotClock {
-  if (!clock) {
-    throw new Error("slot clock unavailable: no status received from the daemon yet");
-  }
-  return clock;
-}
-
-let automationTimer: NodeJS.Timeout | null = null;
-let txEnabled = true;
-
-// Current TX audio frequency and manual slot, mirroring the TUI's AF/slot inputs.
-let currentAf = 1000;
-let currentSlot: TxSlot = "even";
-
-const loggedQsoIds = new Set<string>();
-const workedCalls = new Set<string>();
-
-// Slot survey: hold TX for one receive cycle of our TX parity so the (otherwise
-// deaf) TX slot can be observed, then suggest a clear frequency.
-const SURVEY_LO_HZ = 300;
-const SURVEY_HI_HZ = 2700;
-const SURVEY_DECODE_LAG_SECONDS = 5;
-// Arm this many virtual seconds before the slot opens, so the daemon has time to
-// hand the message to the engine. Virtual, so it scales with the clock.
-const AUTOMATION_LEAD_SECONDS = 2;
-let surveyActive = false;
-let surveySlot: TxSlot | null = null;
-let surveyEndSec = 0;
-let surveyTimer: NodeJS.Timeout | null = null;
+// The QSO automation engine. The web server owns no orchestration of its own: it
+// constructs the controller, renders its ControllerState into the browser wire
+// shape, and routes browser commands to controller methods.
+let controller: OperatorController | null = null;
+let daemonClient: DaemonClient | null = null;
 
 // Stable per-QSO colour used to tint decodes/roster rows. Yellow is reserved by
-// the browser for "replying to me", so it is absent from this palette.
+// the browser for "replying to me", so it is absent from this palette. This is a
+// browser presentation concern, so it lives here, not in the engine.
 const QSO_PALETTE = ["#34d3d3", "#d96be0", "#7c9cff", "#57c46a", "#f5a742", "#e0607d"];
 const qsoColors = new Map<string, string>();
 let nextQsoColor = 0;
@@ -135,783 +71,139 @@ function colorFor(id: string): string {
   return color;
 }
 
-// Recent activity log ring, streamed to the browser.
+// Recent activity log ring, streamed to the browser. Fed by the engine's log
+// sink; the engine holds no ring of its own.
 const logLines: LogLineView[] = [];
-function appendLog(level: LogLineView["level"], text: string): void {
+function pushLog(level: LogLineView["level"], text: string): void {
   logLines.push({ level, text });
   if (logLines.length > 200) {
     logLines.splice(0, logLines.length - 200);
   }
-  broadcastState();
 }
 
-// --- daemon connection -----------------------------------------------------
+const qsoLog: QsoLogStore = {
+  append: (entry, engine: EngineKind) => appendQsoLog(entry, qsoLogPathFor(engine)),
+  readAll: () => readQsoLog()
+};
 
-let daemonClient: DaemonClient | null = null;
-let controlClaimPending = false;
+const stateStore: StateStore = {
+  read: () => readTuiState(),
+  write: (patch) => writeTuiState({ dialFreqHz: patch.dialFreqHz ?? null })
+};
 
-function daemonSend(command: DaemonCommand): boolean {
-  if (!daemonClient || !daemonClient.send(command)) {
-    appendLog("warn", "daemon not connected");
-    return false;
-  }
-  return true;
-}
-
-function connectDaemon(): void {
-  const client = new DaemonClient({
-    url: daemonUrl,
-    token,
-    reconnectMs: 2000,
-    logger: (message) => appendLog("error", message)
-  });
-  daemonClient = client;
-
-  client.on("open", () => {
-    appendLog("info", `connected to daemon ${daemonUrl}`);
-    daemonSend({ type: "get_config" });
-    daemonSend({ type: "list_audio_devices" });
-  });
-  client.on("close", () => {
-    controlHeld = false;
-    controlMine = false;
-    controlClaimPending = false;
-    sessionActive = false;
-    latestTxState = "idle";
-    // Drop the daemon's clock on disconnect: there is no authoritative time
-    // base until the next status arrives. Leaving a scaled clock (or an armed
-    // timer) across reconnect is exactly the demo→real footgun.
-    clock = null;
-    engineKind = "ft8cat";
-    clearAutomationState("daemon disconnected");
-    appendLog("warn", "daemon connection closed; retrying in 2s");
-  });
-
-  client.on("status", (msg) => {
-    const { session, tx, control } = msg;
-    const hadControl = controlMine;
-    const previousActive = sessionActive;
-    const previousKind = engineKind;
-    const previousClock = clock;
-
-    // Adopt the daemon's clock. Any field change (not just scale) can move the
-    // next boundary, so re-arm rather than leaving a timer at a stale anchor.
-    const clockDirty =
-      previousClock === null ||
-      previousClock.spec.epochMs !== msg.clock.epochMs ||
-      previousClock.spec.anchorWallMs !== msg.clock.anchorWallMs ||
-      previousClock.spec.slotMs !== msg.clock.slotMs ||
-      previousClock.spec.scale !== msg.clock.scale;
-    clock = new SlotClock(msg.clock);
-    engineKind = msg.engine;
-
-    if (session.callsign !== null) {
-      myCall = session.callsign;
-    }
-    if (session.grid !== null) {
-      myGrid = session.grid;
-    }
-    controlHeld = control.held;
-    controlMine = control.byThisClient;
-    if (controlMine || !controlHeld) {
-      controlClaimPending = false;
-    }
-    sessionActive = session.active;
-    catConnected = session.catConnected;
-
-    const sessionEnded = previousActive && !session.active;
-    const kindChanged = previousKind !== msg.engine;
-    // Demo→real at scale 1 never trips a scale-only dirty check. Clear in-flight
-    // QSOs so leftover QQ0DEMO CQs cannot key the live radio or land in the
-    // real QSO log when they complete under the new engine.
-    if (sessionEnded || kindChanged) {
-      clearAutomationState(sessionEnded ? "session stopped" : "engine changed");
-    } else if (clockDirty) {
-      clearAutomationTimer();
-    }
-
-    updateTxState(tx.state);
-
-    if (sessionActive && ((!hadControl && controlMine) || clockDirty || (kindChanged && !sessionEnded))) {
-      scheduleAutomation();
-    }
-    broadcastState();
-  });
-
-  client.on("decode", (msg) => {
-    const record: DecodeRecord = { ts: msg.ts, snr: msg.snr, dt: msg.dt, af: msg.af, message: msg.message };
-    decodes.push(record);
-    if (decodes.length > 2000) {
-      decodes.splice(0, decodes.length - 2000);
-    }
-    const events = automation.handleDecode(record, myCall, myGrid);
-    if (events.length > 0) {
-      handleQsoEvents(events);
-      cancelSurvey("answering caller");
-      scheduleAutomation();
-    }
-    broadcastState();
-  });
-
-  client.on("tx", (msg) => {
-    appendLog("tx", `[tx] af=${msg.af} ${msg.message}`);
-    const result = automation.confirmTransmission(pendingAutomationTx, { ts: msg.ts, af: msg.af, message: msg.message });
-    if (result.matched) {
-      activeAutomationTx = pendingAutomationTx;
-      pendingAutomationTx = null;
-    }
-    if (result.events.length > 0) {
-      handleQsoEvents(result.events);
-    }
-    scheduleAutomation();
-  });
-
-  client.on("tx_update", (msg) => updateTxState(msg.state));
-
-  client.on("log", (msg) => appendLog(msg.level, `[daemon] ${msg.message}`));
-
-  client.on("daemonError", (msg) => {
-    if (msg.code === "CONTROL_REQUIRED" || msg.code === "CONTROL_UNAVAILABLE") {
-      controlClaimPending = false;
-      appendLog("warn", "control is held by another client");
-    } else {
-      appendLog("error", `[error] ${msg.code}: ${msg.message}`);
-    }
-    if (pendingAutomationTx) {
-      pendingAutomationTx = null;
-      activeAutomationTx = null;
-      scheduledAutomationTx = null;
-      scheduleAutomation();
-    }
-  });
-
-  client.on("config", (msg) => {
-    configComplete = msg.complete;
-    configMissing = msg.missing ?? [];
-    if (msg.session?.callsign) {
-      myCall = msg.session.callsign;
-    }
-    if (msg.session?.grid) {
-      myGrid = msg.session.grid;
-    }
-    appendLog("info", `[config] complete=${msg.complete}`);
-    broadcastState();
-  });
-
-  client.on("audio_devices", (msg) => {
-    setupDevices = msg.devices.map((device) => ({
-      id: device.id,
-      name: device.name,
-      defaultSampleRate: device.defaultSampleRate ?? null
-    }));
-    broadcastState();
-  });
-
-  client.connect();
-}
-
-// --- QSO event handling / logging ------------------------------------------
-
-function handleQsoEvents(events: QsoAutomationEvent[]): void {
-  for (const event of events) {
-    switch (event.type) {
-      case "qso_created":
-        colorFor(event.qso.id);
-        appendLog("qso", `[qso] created ${event.qso.theirCall ?? "CQ"}`);
-        break;
-      case "qso_updated":
-        appendLog("qso", `[qso] ${event.qso.theirCall} ${event.previousStep} -> ${event.qso.step}`);
-        break;
-      case "qso_completed":
-        appendLog("qso", `[qso] complete ${event.qso.theirCall ?? "CQ"} (${event.reason})`);
-        void logCompletedQso(event.qso, event.reason);
-        break;
-      case "qso_timed_out":
-        appendLog("qso", `[qso] timed out ${event.qso.theirCall ?? "CQ"} step=${event.qso.step}`);
-        break;
-      case "cq_stopped":
-        appendLog("qso", "[qso] CQ stopped after reply");
-        break;
-    }
-  }
-  broadcastState();
-}
-
-async function logCompletedQso(qso: QsoRecord, reason: string): Promise<void> {
-  if (loggedQsoIds.has(qso.id)) {
-    return;
-  }
-  const entry = automation.toLogEntry(qso, reason, dialFreqHz);
-  if (!entry) {
-    return;
-  }
-  loggedQsoIds.add(qso.id);
-  try {
-    await appendQsoLog(entry, qsoLogPathFor(engineKind));
-    workedCalls.add(entry.theirCall.toUpperCase());
-    appendLog("info", `[qso-log] wrote ${entry.theirCall}${dialFreqHz ? "" : " (no freq set)"}`);
-  } catch (error) {
-    loggedQsoIds.delete(qso.id);
-    appendLog("error", `[qso-log error] ${error instanceof Error ? error.message : String(error)}`);
-  }
-}
-
-// --- scheduler -------------------------------------------------------------
-
-// The slot we transmit in: the active CQ row's slot, else the manual slot.
-function currentTxSlot(): TxSlot {
-  const cq = automation.qsos.find((qso) => qso.kind === "calling-cq" && qso.status === "active");
-  return cq ? cq.nextSlot : currentSlot;
-}
-
-function currentAfOrNull(): number | null {
-  if (!Number.isInteger(currentAf) || currentAf < 200 || currentAf > 3000) {
-    return null;
-  }
-  return currentAf;
-}
-
-function clearAutomationTimer(): void {
-  if (automationTimer) {
-    clearTimeout(automationTimer);
-    automationTimer = null;
-  }
-  scheduledAutomationTx = null;
-}
-
-function clearAutomationState(_reason: string): void {
-  clearAutomationTimer();
-  if (surveyActive) {
-    cancelSurvey("session boundary");
-  }
-  automation.qsos.splice(0);
-  pendingAutomationTx = null;
-  activeAutomationTx = null;
-  scheduledAutomationTx = null;
-}
-
-// Re-arm automation on the falling edge of "active" (a transmission finished),
-// or on a genuine "idle" (e.g. after cancel). The daemon rests in "pending"
-// after a TX, so we never rely on seeing "idle" to resume.
-function updateTxState(next: TxState): void {
-  const wasActive = latestTxState === "active";
-  latestTxState = next;
-  if (wasActive && next !== "active") {
-    activeAutomationTx = null;
-  }
-  if (surveyActive || next === "active") {
-    return;
-  }
-  if (wasActive || next === "idle") {
-    scheduleAutomation();
-  }
-}
-
-function scheduleAutomation(): void {
-  clearAutomationTimer();
-
-  if (!sessionActive || surveyActive || !txEnabled || latestTxState === "active") {
-    broadcastState();
-    return;
-  }
-
-  const af = currentAfOrNull();
-  if (af === null) {
-    broadcastState();
-    return;
-  }
-
-  const tx = automation.nextTransmission(af);
-  if (!tx) {
-    broadcastState();
-    return;
-  }
-
-  scheduledAutomationTx = tx;
-  if (!ensureAutomationControl()) {
-    broadcastState();
-    return;
-  }
-
-  if (!clock) {
-    appendLog("warn", "[automation] paused: awaiting the slot clock from the daemon");
-    broadcastState();
-    return;
-  }
-
-  // Arm two virtual seconds before the slot opens. The lead is a virtual
-  // quantity, so it scales with everything else; the clock converts it to the
-  // wall delay this setTimeout actually needs.
-  const delayMs = clock.wallDelayUntilSlot(tx.intent.slot, AUTOMATION_LEAD_SECONDS);
-  automationTimer = setTimeout(() => sendAutomatedTx(tx), delayMs);
-  broadcastState();
-}
-
-function sendAutomatedTx(tx: AutomationTx): void {
-  automationTimer = null;
-  scheduledAutomationTx = null;
-  if (!sessionActive || surveyActive || !txEnabled || latestTxState === "active") {
-    return;
-  }
-  const af = currentAfOrNull();
-  if (af === null) {
-    appendLog("warn", "automation paused: invalid AF");
-    return;
-  }
-  if (!ensureAutomationControl()) {
-    scheduledAutomationTx = tx;
-    broadcastState();
-    return;
-  }
-  const refreshed: AutomationTx = { ...tx, intent: { ...tx.intent, af } };
-  pendingAutomationTx = refreshed;
-  daemonSend({ type: "transmit", ...refreshed.intent });
-  broadcastState();
-}
-
-// --- slot survey -----------------------------------------------------------
-
-function startSurvey(): void {
-  if (surveyActive) {
-    return;
-  }
-  const slot = currentTxSlot();
-  surveyActive = true;
-  surveySlot = slot;
-
-  clearAutomationTimer();
-  if (pendingAutomationTx) {
-    daemonSend({ type: "cancel_transmit" });
-    pendingAutomationTx = null;
-  }
-  activeAutomationTx = null;
-  scheduledAutomationTx = null;
-
-  if (!clock) {
-    appendLog("warn", "[survey] unavailable: awaiting the slot clock from the daemon");
-    surveyActive = false;
-    broadcastState();
-    return;
-  }
-
-  // Hold TX for one whole slot past the boundary, plus decode latency. That is a
-  // negative offset -- we wait past the slot rather than arming before it -- and
-  // the slot length comes from the clock, never a literal 15.
-  const slotSeconds = clock.spec.slotMs / 1000;
-  const pastBoundary = slotSeconds + SURVEY_DECODE_LAG_SECONDS;
-  const delaySec = clock.secondsUntilSlot(slot) + pastBoundary;
-  // surveyEndSec is a rendered deadline, not a delay, so it lives in the clock's
-  // virtual base -- the same base the countdown is compared against.
-  surveyEndSec = clock.virtualDeadlineAfter(delaySec);
-  appendLog("info", `[survey] holding TX ~${delaySec}s to listen on the ${slot} slot`);
-  if (surveyTimer) {
-    clearTimeout(surveyTimer);
-  }
-  surveyTimer = setTimeout(finishSurvey, clock.wallDelayUntilSlot(slot, -pastBoundary));
-  broadcastState();
-}
-
-function finishSurvey(): void {
-  surveyTimer = null;
-  const slot = surveySlot;
-  surveyActive = false;
-  surveySlot = null;
-  if (slot) {
-    const occupied = latestSlotAfs(decodes, slot);
-    const suggestion = suggestClearAf(occupied, SURVEY_LO_HZ, SURVEY_HI_HZ);
-    currentAf = suggestion;
-    appendLog("info", `[survey] ${slot} slot updated, clear@${suggestion}Hz (${occupied.length} sigs)`);
-  }
-  scheduleAutomation();
-}
-
-function cancelSurvey(reason: string): void {
-  if (!surveyActive) {
-    return;
-  }
-  if (surveyTimer) {
-    clearTimeout(surveyTimer);
-    surveyTimer = null;
-  }
-  surveyActive = false;
-  surveySlot = null;
-  appendLog("info", `[survey] aborted (${reason})`);
-}
-
-// --- operator actions ------------------------------------------------------
-
-function ensureControl(): boolean {
-  if (controlMine) {
-    return true;
-  }
-  if (controlHeld) {
-    appendLog("warn", "you do not have control (another client holds it)");
-    return false;
-  }
-  return daemonSend({ type: "claim_control", ...(token ? { token } : {}) });
-}
-
-function ensureAutomationControl(): boolean {
-  if (controlMine) {
-    return true;
-  }
-  if (controlHeld) {
-    appendLog("warn", "automation paused: another client has control");
-    return false;
-  }
-  if (!controlClaimPending && daemonSend({ type: "claim_control", ...(token ? { token } : {}) })) {
-    controlClaimPending = true;
-    appendLog("info", "[control] claiming daemon control for automation");
-  }
-  return false;
-}
-
-function ensureIdentity(): boolean {
-  if (!myCall || !myGrid) {
-    appendLog("warn", "automation requires a callsign and grid");
-    return false;
-  }
-  if (!clock) {
-    appendLog("warn", "automation paused: awaiting the slot clock from the daemon");
-    return false;
-  }
-  return true;
-}
-
-function setIdentity(call: string, grid: string): void {
-  myCall = call.trim().toUpperCase();
-  myGrid = grid.trim().toUpperCase();
-}
-
-function applyOptionalIdentity(message: { myCall?: string; myGrid?: string }): void {
-  if (typeof message.myCall === "string" && typeof message.myGrid === "string") {
-    const nextCall = message.myCall.trim().toUpperCase();
-    const nextGrid = message.myGrid.trim().toUpperCase();
-    if (nextCall || nextGrid) {
-      myCall = nextCall;
-      myGrid = nextGrid;
-    }
-  }
-}
-
-function findLastDecodeFrom(call: string): DecodeRecord | null {
-  for (let index = decodes.length - 1; index >= 0; index--) {
-    if (senderOf(decodes[index]!.message) === call) {
-      return decodes[index]!;
-    }
-  }
-  return null;
-}
-
-function callCq(slot?: TxSlot): void {
-  if (!ensureIdentity()) {
-    return;
-  }
-  if (automation.isCallingCq()) {
-    stopCq("operator stopped CQ");
-    return;
-  }
-  if (slot) {
-    currentSlot = slot;
-  }
-  automation.createCq(myCall, myGrid, slot ?? currentSlot, "top");
-  appendLog("qso", "[qso] calling CQ");
-  scheduleAutomation();
-}
-
-function stopCq(reason: string): void {
-  const cq = automation.qsos.find((qso) => qso.kind === "calling-cq" && qso.status === "active");
-  if (!cq) {
-    return;
-  }
-
-  const shouldCancelDaemonTx =
-    pendingAutomationTx?.qsoId === cq.id ||
-    activeAutomationTx?.qsoId === cq.id;
-
-  automation.abandon(cq.id);
-  if (scheduledAutomationTx?.qsoId === cq.id) {
-    clearAutomationTimer();
-  }
-  if (pendingAutomationTx?.qsoId === cq.id) {
-    pendingAutomationTx = null;
-  }
-  if (activeAutomationTx?.qsoId === cq.id) {
-    activeAutomationTx = null;
-  }
-  if (shouldCancelDaemonTx) {
-    daemonSend({ type: "cancel_transmit" });
-  }
-  appendLog("qso", `[qso] ${reason}`);
-  scheduleAutomation();
-}
-
-function setTxSlot(slot: TxSlot): void {
-  currentSlot = slot;
-  const cq = automation.qsos.find((qso) => qso.kind === "calling-cq" && qso.status === "active");
-  if (cq) {
-    cq.nextSlot = slot;
-    cq.updatedAt = new Date().toISOString();
-  }
-}
-
-function replyToCall(rawCall: string): void {
-  if (!ensureIdentity()) {
-    return;
-  }
-  const call = rawCall.trim().toUpperCase();
-  if (!/^[A-Z0-9/]{2,}$/.test(call)) {
-    appendLog("warn", `'${call}' is not a valid callsign`);
-    return;
-  }
-  const existing = automation.qsos.find(
-    (qso) => qso.kind === "standard" && qso.theirCall === call && qso.status !== "complete"
-  );
-  if (existing) {
-    appendLog("info", `QSO already exists for ${call}`);
-    return;
-  }
-  const last = findLastDecodeFrom(call);
-  const nextSlot = last ? oppositeSlot(slotFromTimestamp(last.ts)) : currentSlot;
-  const theirGrid = last ? gridFrom(last.message) : null;
-  const qso = automation.createReplyToCall(call, myCall, myGrid, nextSlot, theirGrid, "top");
-  colorFor(qso.id);
-  appendLog("qso", `[qso] reply to ${qso.theirCall}`);
-  scheduleAutomation();
-}
-
-function qsoAction(id: string, action: string): void {
-  switch (action) {
-    case "complete":
-      handleQsoEvents(automation.complete(id));
-      break;
-    case "abandon":
-      automation.abandon(id);
-      break;
-    case "resume":
-      automation.resume(id);
-      break;
-    case "retry":
-      automation.resetAttempts(id);
-      break;
-    case "prevStep":
-      automation.previousStep(id);
-      break;
-    case "nextStep":
-      automation.nextStep(id);
-      break;
-    case "moveUp":
-      automation.move(id, -1);
-      break;
-    case "moveDown":
-      automation.move(id, 1);
-      break;
-    default:
-      appendLog("warn", `unknown qso action '${action}'`);
-      return;
-  }
-  scheduleAutomation();
-}
-
-function setDialFreq(mhz: number | null): void {
-  if (mhz === null) {
-    dialFreqHz = null;
-  } else if (!Number.isFinite(mhz) || mhz <= 0) {
-    appendLog("warn", "freq: enter a positive frequency in MHz (e.g. 14.074)");
-    return;
-  } else {
-    dialFreqHz = Math.round(mhz * 1e6);
-    const band = bandForMHz(mhz);
-    appendLog("info", `[freq] dial = ${mhz.toFixed(3)} MHz${band ? ` (${band})` : " (out of ham band?)"}`);
-  }
-  void writeTuiState({ dialFreqHz }).catch((error) =>
-    appendLog("error", `[state error] ${error instanceof Error ? error.message : String(error)}`)
-  );
-  broadcastState();
-}
-
-function haltTx(): void {
-  daemonSend({ type: "cancel_transmit" });
-  cancelSurvey("halted");
-  pendingAutomationTx = null;
-  activeAutomationTx = null;
-  scheduledAutomationTx = null;
-  clearAutomationTimer();
-  txEnabled = false;
-  automation.pauseAll("halted");
-  appendLog("warn", "[tx] halted by operator");
-  broadcastState();
-}
-
-function setTxEnabled(enabled: boolean): void {
-  txEnabled = enabled;
-  if (!enabled) {
-    clearAutomationTimer();
-    appendLog("info", "[tx] disabled — current transmission will finish");
-  } else {
-    // Resuming re-activates anything paused by a prior halt.
-    for (const qso of automation.qsos) {
-      if (qso.status === "paused") {
-        automation.resume(qso.id);
-      }
-    }
-    appendLog("info", "[tx] enabled");
-    scheduleAutomation();
-  }
-  broadcastState();
-}
+// --- command dispatch ------------------------------------------------------
 
 function handleCommand(message: CommandMessage): void {
+  if (!controller) {
+    return;
+  }
   switch (message.cmd) {
     case "setIdentity":
-      setIdentity(message.call, message.grid);
-      appendLog("info", `[identity] ${myCall} ${myGrid}`);
-      broadcastState();
+      controller.setIdentity(message.call, message.grid);
       break;
     case "setDialFreq":
-      setDialFreq(message.mhz);
+      controller.setDialFreq(message.mhz);
       break;
     case "callCq":
-      applyOptionalIdentity(message);
-      callCq(message.slot);
+      controller.callCq(message.slot, { myCall: message.myCall, myGrid: message.myGrid });
       break;
     case "replyToCall":
-      applyOptionalIdentity(message);
-      replyToCall(message.call);
+      controller.replyToCall(message.call, { myCall: message.myCall, myGrid: message.myGrid });
       break;
     case "qso":
-      qsoAction(message.id, message.action);
+      controller.qsoAction(message.id, message.action);
       break;
     case "setAf":
-      if (Number.isInteger(message.af)) {
-        currentAf = message.af;
-        scheduleAutomation();
-      }
+      controller.setAf(message.af);
       break;
     case "setSlot":
-      setTxSlot(message.slot);
-      scheduleAutomation();
+      controller.setSlot(message.slot);
       break;
     case "survey":
-      startSurvey();
+      controller.survey();
       break;
     case "txEnable":
-      setTxEnabled(message.enabled);
+      controller.setTxEnabled(message.enabled);
       break;
     case "haltTx":
-      haltTx();
+      controller.haltTx();
       break;
     case "session":
-      if (!ensureControl()) {
-        return;
+      if (message.action === "start") {
+        controller.startSession();
+      } else {
+        controller.stopSession();
       }
-      if (message.action === "start" && !configComplete) {
-        appendLog("warn", "complete station setup before starting a session");
-        broadcastState();
-        return;
-      }
-      daemonSend(message.action === "start" ? { type: "start_session" } : { type: "stop_session" });
       break;
     case "startDemo":
-      if (!ensureControl()) {
-        return;
-      }
-      // No configComplete guard: the whole point is that a user with no radio has
-      // no config to satisfy it with. The daemon synthesizes a demo identity.
-      appendLog("info", "[demo] starting on the simulated engine — nothing is transmitted");
-      daemonSend({ type: "start_session", demo: true });
+      controller.startDemo();
       break;
     case "saveSetup":
-      if (!ensureControl()) {
-        return;
-      }
-      if (sessionActive) {
-        appendLog("warn", "cannot save setup while a session is active");
-        return;
-      }
-      daemonSend({
-        type: "save_config",
-        session: {
-          mode: "FT8",
-          device: { id: message.deviceId },
-          callsign: message.callsign,
-          grid: message.grid,
-          cat: { mode: message.catMode, port: message.catPort }
-        }
+      controller.saveSetup({
+        deviceId: message.deviceId,
+        callsign: message.callsign,
+        grid: message.grid,
+        catMode: message.catMode,
+        catPort: message.catPort
       });
       break;
     case "releaseControl":
-      if (!controlMine) {
-        appendLog("warn", "control is not held by this client");
-        return;
-      }
-      daemonSend({ type: "release_control" });
+      controller.releaseControl();
       break;
     default:
-      appendLog("warn", "unknown command");
+      pushLog("warn", "unknown command");
   }
 }
 
 // --- view-model / broadcast ------------------------------------------------
 
-function buildState(): StateMessage {
+function buildState(state: ControllerState): StateMessage {
   // Two clocks, deliberately. `wallNowMs` is what the browser corrects its own
   // clock against (it runs on a different machine). `nowMs` is virtual time --
   // the base decode timestamps live in -- and everything slot-shaped uses it.
   // Mixing them is how a scaled countdown ends up disagreeing with the band.
   const wallNowMs = Date.now();
-  const nowMs = clock ? clock.now() : wallNowMs;
+  const nowMs = state.clock ? state.clock.now() : wallNowMs;
 
   const activeCallColors = new Map<string, string>();
-  for (const qso of automation.qsos) {
-    if (qso.kind === "standard" && qso.status !== "complete" && qso.theirCall) {
+  for (const qso of state.qsos.active) {
+    if (qso.kind === "standard" && qso.theirCall) {
       activeCallColors.set(qso.theirCall, colorFor(qso.id));
     }
   }
-  const ctx: AnnotateContext = { myCall, activeCallColors, workedCalls };
+  const ctx: AnnotateContext = {
+    myCall: state.station.call,
+    activeCallColors,
+    workedCalls: state.workedCalls
+  };
 
-  const recentDecodes = decodes.slice(-200).map((record) => annotateDecode(record, ctx));
-  const rosters = buildRosters(decodes, ctx, nowMs);
-  const txingQsoId = pendingAutomationTx?.qsoId ?? activeAutomationTx?.qsoId ?? null;
-  const displayAutomationTx = pendingAutomationTx ?? activeAutomationTx ?? scheduledAutomationTx;
+  const recentDecodes = state.decodes.slice(-200).map((record) => annotateDecode(record, ctx));
+  const rosters = buildRosters(state.decodes, ctx, nowMs);
 
   return {
     type: "state",
     serverNow: wallNowMs,
-    cycle: buildCycleView(clock, wallNowMs, nowMs),
-    station: {
-      call: myCall,
-      grid: myGrid,
-      dialFreqHz,
-      catConnected,
-      sessionActive,
-      controlHeld,
-      controlMine,
-      demo: engineKind === "simulated"
-    },
-    setup: {
-      complete: configComplete,
-      missing: configMissing,
-      devices: setupDevices
-    },
+    cycle: buildCycleView(state.clock, wallNowMs, nowMs),
+    station: state.station,
+    setup: state.setup,
     now: {
-      ...deriveTxCard(latestTxState, displayAutomationTx),
-      txEnabled,
-      surveyActive,
-      surveySlot,
-      surveyEndSec
+      ...deriveTxCard(state.tx.state, state.tx.displayTx),
+      txEnabled: state.tx.enabled,
+      surveyActive: state.survey.active,
+      surveySlot: state.survey.slot,
+      surveyEndSec: state.survey.endSec
     },
-    af: { value: currentAf, slot: currentTxSlot() },
+    af: state.af,
     qsos: {
-      callingCq: automation.isCallingCq(),
-      active: buildActiveQsoView(automation.qsos, colorFor, txingQsoId, nowMs),
-      completed: buildCompletedView(automation.qsos)
+      callingCq: state.qsos.callingCq,
+      active: buildActiveQsoView(state.qsos.active, colorFor, state.tx.txingQsoId, nowMs),
+      completed: buildCompletedView(state.qsos.completed)
     },
     decodes: recentDecodes,
     rosters,
     occupancy: {
-      even: latestSlotAfs(decodes, "even"),
-      odd: latestSlotAfs(decodes, "odd")
+      even: latestSlotAfs(state.decodes, "even"),
+      odd: latestSlotAfs(state.decodes, "odd")
     },
     log: logLines.slice(-200)
   };
@@ -920,10 +212,10 @@ function buildState(): StateMessage {
 const clients = new Set<WebSocket>();
 
 function broadcastState(): void {
-  if (clients.size === 0) {
+  if (clients.size === 0 || !controller) {
     return;
   }
-  const data = JSON.stringify(buildState());
+  const data = JSON.stringify(buildState(controller.state));
   for (const client of clients) {
     if (client.readyState === WebSocket.OPEN) {
       client.send(data);
@@ -977,7 +269,9 @@ httpServer.on("upgrade", (req: IncomingMessage, socket: Duplex, head: Buffer) =>
 
 browserWss.on("connection", (client: WebSocket) => {
   clients.add(client);
-  client.send(JSON.stringify(buildState()));
+  if (controller) {
+    client.send(JSON.stringify(buildState(controller.state)));
+  }
   client.on("message", (raw: RawData) => {
     try {
       const message = JSON.parse(raw.toString()) as CommandMessage;
@@ -985,7 +279,7 @@ browserWss.on("connection", (client: WebSocket) => {
         handleCommand(message);
       }
     } catch (error) {
-      appendLog("error", `bad command: ${error instanceof Error ? error.message : String(error)}`);
+      pushLog("error", `bad command: ${error instanceof Error ? error.message : String(error)}`);
     }
   });
   client.on("close", () => clients.delete(client));
@@ -993,62 +287,10 @@ browserWss.on("connection", (client: WebSocket) => {
 
 // --- startup ---------------------------------------------------------------
 
-async function loadPersistedState(): Promise<void> {
-  try {
-    const state = await readTuiState();
-    if (state.dialFreqHz != null) {
-      dialFreqHz = state.dialFreqHz;
-    }
-  } catch {
-    // Non-fatal: start without a restored dial frequency.
-  }
-  try {
-    for (const entry of await readQsoLog()) {
-      if (entry.theirCall) {
-        workedCalls.add(entry.theirCall.toUpperCase());
-      }
-    }
-  } catch {
-    // Non-fatal: start with an empty worked-call set.
-  }
-}
-
 let broadcastInterval: NodeJS.Timeout | null = null;
 let started = false;
 
-function resetControllerState(): void {
-  decodes.splice(0);
-  automation.qsos.splice(0);
-  myCall = "";
-  myGrid = "";
-  dialFreqHz = null;
-  controlHeld = false;
-  controlMine = false;
-  controlClaimPending = false;
-  sessionActive = false;
-  catConnected = false;
-  latestTxState = "idle";
-  pendingAutomationTx = null;
-  activeAutomationTx = null;
-  scheduledAutomationTx = null;
-  txEnabled = true;
-  currentAf = 1000;
-  currentSlot = "even";
-  loggedQsoIds.clear();
-  workedCalls.clear();
-  surveyActive = false;
-  surveySlot = null;
-  surveyEndSec = 0;
-  qsoColors.clear();
-  nextQsoColor = 0;
-  logLines.splice(0);
-}
-
-async function waitUntil(
-  predicate: () => boolean,
-  label: string,
-  timeoutMs: number
-): Promise<void> {
+async function waitUntil(predicate: () => boolean, label: string, timeoutMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (!predicate()) {
     if (Date.now() >= deadline) {
@@ -1059,30 +301,17 @@ async function waitUntil(
 }
 
 /**
- * Claim control and start a demo session with no browser messages.
- * The smoke harness uses this so it drives the same QsoAutomation path as the UI.
+ * Claim control and start a demo session with no browser messages. The smoke
+ * harness uses this so it drives the same engine path as the UI.
  */
 async function bootstrapHeadlessDemo(): Promise<void> {
   await waitUntil(() => daemonClient?.connected === true, "daemon connection", 15_000);
-
-  if (!controlMine) {
-    if (!daemonSend({ type: "claim_control", ...(token ? { token } : {}) })) {
-      throw new Error("headless: failed to send claim_control");
-    }
-    await waitUntil(() => controlMine, "control claim", 10_000);
-  }
-
-  if (!sessionActive) {
-    appendLog("info", "[demo] headless: starting on the simulated engine — nothing is transmitted");
-    if (!daemonSend({ type: "start_session", demo: true })) {
-      throw new Error("headless: failed to send start_session");
-    }
-    await waitUntil(
-      () => sessionActive && Boolean(myCall) && Boolean(myGrid) && clock !== null,
-      "demo session",
-      15_000
-    );
-  }
+  pushLog("info", "[demo] headless: starting on the simulated engine — nothing is transmitted");
+  controller?.startDemo();
+  await waitUntil(() => {
+    const s = controller?.state;
+    return Boolean(s?.station.sessionActive && s.station.call && s.station.grid && s.clock);
+  }, "demo session", 15_000);
 }
 
 export async function startWebUiServer(options: WebUiServerOptions = {}): Promise<void> {
@@ -1094,9 +323,30 @@ export async function startWebUiServer(options: WebUiServerOptions = {}): Promis
   webPort = options.webPort ?? webPort;
   webHost = options.webHost ?? webHost;
 
-  resetControllerState();
-  await loadPersistedState();
-  connectDaemon();
+  // Fresh view state on each start.
+  logLines.splice(0);
+  qsoColors.clear();
+  nextQsoColor = 0;
+
+  daemonClient = new DaemonClient({
+    url: daemonUrl,
+    token,
+    reconnectMs: 2000,
+    logger: (message) => {
+      pushLog("error", message);
+      broadcastState();
+    }
+  });
+  controller = createOperatorController({
+    client: daemonClient,
+    log: qsoLog,
+    state: stateStore,
+    token,
+    onLog: pushLog,
+    bandForMHz
+  });
+  controller.onChange(() => broadcastState());
+  controller.start();
 
   await new Promise<void>((resolve, reject) => {
     const onError = (error: Error) => {
@@ -1128,14 +378,13 @@ export async function startWebUiServer(options: WebUiServerOptions = {}): Promis
 
 export async function closeWebUiServer(): Promise<void> {
   started = false;
-  clearAutomationTimer();
-  if (surveyTimer) {
-    clearTimeout(surveyTimer);
-    surveyTimer = null;
-  }
   if (broadcastInterval) {
     clearInterval(broadcastInterval);
     broadcastInterval = null;
+  }
+  if (controller) {
+    controller.dispose();
+    controller = null;
   }
   if (daemonClient) {
     daemonClient.close();

--- a/ui/web/server.ts
+++ b/ui/web/server.ts
@@ -33,7 +33,7 @@ import {
   latestSlotAfs,
   senderOf,
   type AnnotateContext
-} from "./view-model.js";
+} from "../../core/view-model.js";
 import type { CommandMessage, LogLineView, SetupView, StateMessage, TxState } from "./protocol.js";
 
 let daemonUrl = process.env.DIGI_DX_URL ?? "ws://127.0.0.1:8788";


### PR DESCRIPTION
## What

W2 of the rebuild plan: extract the QSO automation engine (`OperatorController`) out of the two clients into one headless module both drive. The pure QSO state machine (`core/qso.ts`) was already extracted in W1; this lifts the orchestration around it — the slot-aligned scheduler, survey, control-claim, tx-enable, decode buffer, dial-freq, and worked-call/logging — into `core/controller.ts`. The web server and TUI become thin.

Plan: `docs/plans/2026-07-14-001-refactor-operator-controller-plan.md`.

## Why

The rebuild review found QSO orchestration duplicated across the TUI and web clients and already drifting (finding #4). Demo mode and the published slot clock were then each paid for twice and widened that drift. Extracting one engine both clients drive stops the drift and makes the previously-untestable TUI logic testable.

## How (units, in order)

- **U3** — relocate `ui/web/view-model.ts` → `core/view-model.ts` with its view types, so it depends only on core.
- **U1/U2** — build `core/controller.ts` and port the web server's orchestration into it behind an injected-dependency seam (`DaemonClient`, `QsoLogStore`, `StateStore`, band namer). `ControllerState` mirrors what the web server rendered, so the view-model stays a pure transform. Scheduling still derives from the daemon's slot clock **including scale** (R5).
- **U4** — reduce `ui/web/server.ts` to transport + `ControllerState → StateMessage` mapping (1169 → 418 lines).
- **U5** — headless full-QSO integration proof: drives the controller directly against the simulated driver at scale 100, completing and logging a QSO in ~1s wall. The wall-time bound proves the scheduler honors the clock's scale factor.
- **U6** — reduce `ui/tui.ts` to render + input on the controller (1571 → 997 lines). Band Activity keeps lightweight decode/tx listeners on the shared client for its append-driven log; everything else is driven by `onChange`.

## Behavior note (R3)

This is not a pure behavior-preserving refactor: the two clients converge to **one** behavior, and the web client's control model wins. The TUI's drifted `manualOverridePending` model is replaced — CANCEL now toggles halt/resume via `txEnabled`.

## Verification

- `npm test` (171, +11 new: controller unit + integration proof), `npm run build`, `npm run typecheck` — green.
- `npm run smoke` (headless QSO through the controller) and `npm run smoke:ui` (browser QSO + screenshots) — green.
- Structural: no orchestration symbols remain in `ui/web/server.ts` or `ui/tui.ts`; `core/` imports nothing from `ui/`.

## Out of scope

Daemon promotion (option B), new QSO automation behavior, wire-protocol changes, W5 security. Relocating `ui/qso-log.ts` into `core/` is deferred (injected instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y6H7jxQvfjySrJbcsfjWJV
